### PR TITLE
Add mypy support and fixup project to give no errors

### DIFF
--- a/canopen/emcy.py
+++ b/canopen/emcy.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import struct
 import logging
 import threading
@@ -52,7 +53,7 @@ class EmcyConsumer:
 
     def wait(
         self, emcy_code: Optional[int] = None, timeout: float = 10
-    ) -> "EmcyError":
+    ) -> Optional[EmcyError]:
         """Wait for a new EMCY to arrive.
 
         :param emcy_code: EMCY code to wait for
@@ -86,10 +87,14 @@ class EmcyProducer:
         self.cob_id = cob_id
 
     def send(self, code: int, register: int = 0, data: bytes = b""):
+        if self.network is None:
+            raise RuntimeError("A Network is required")
         payload = EMCY_STRUCT.pack(code, register, data)
         self.network.send_message(self.cob_id, payload)
 
     def reset(self, register: int = 0, data: bytes = b""):
+        if self.network is None:
+            raise RuntimeError("A Network is required")
         payload = EMCY_STRUCT.pack(0, register, data)
         self.network.send_message(self.cob_id, payload)
 

--- a/canopen/emcy.py
+++ b/canopen/emcy.py
@@ -90,14 +90,10 @@ class EmcyProducer:
         self.cob_id = cob_id
 
     def send(self, code: int, register: int = 0, data: bytes = b""):
-        if self.network is None:
-            raise RuntimeError("A Network is required")
         payload = EMCY_STRUCT.pack(code, register, data)
         self.network.send_message(self.cob_id, payload)
 
     def reset(self, register: int = 0, data: bytes = b""):
-        if self.network is None:
-            raise RuntimeError("A Network is required")
         payload = EMCY_STRUCT.pack(0, register, data)
         self.network.send_message(self.cob_id, payload)
 

--- a/canopen/nmt.py
+++ b/canopen/nmt.py
@@ -145,8 +145,6 @@ class NmtMaster(NmtBase):
         super(NmtMaster, self).send_command(code)
         logger.info(
             "Sending NMT command 0x%X to node %d", code, self.id)
-        if self.network is None:
-            raise RuntimeError("A Network is required")
         self.network.send_message(0, [code, self.id])
 
     def wait_for_heartbeat(self, timeout: float = 10):
@@ -189,8 +187,6 @@ class NmtMaster(NmtBase):
             Period (in seconds) at which the node guarding should be advertised to the slave node.
         """
         if self._node_guarding_producer : self.stop_node_guarding()
-        if self.network is None:
-            raise RuntimeError("A Network is required")
         self._node_guarding_producer = self.network.send_periodic(0x700 + self.id, [], period, True)
 
     def stop_node_guarding(self):
@@ -226,8 +222,6 @@ class NmtSlave(NmtBase):
 
         if self._state == 0:
             logger.info("Sending boot-up message")
-            if self.network is None:
-                raise RuntimeError("A Network is required")
             self.network.send_message(0x700 + self.id, [0])
 
         # The heartbeat service should start on the transition
@@ -258,8 +252,6 @@ class NmtSlave(NmtBase):
         self.stop_heartbeat()
         if heartbeat_time_ms > 0:
             logger.info("Start the heartbeat timer, interval is %d ms", self._heartbeat_time_ms)
-            if self.network is None:
-                raise RuntimeError("A network is required")
             self._send_task = self.network.send_periodic(
                 0x700 + self.id, [self._state], heartbeat_time_ms / 1000.0)
 

--- a/canopen/node/base.py
+++ b/canopen/node/base.py
@@ -1,4 +1,4 @@
-from typing import TextIO, Union
+from typing import TextIO, Union, Optional
 from canopen.objectdictionary import ObjectDictionary, import_od
 
 
@@ -14,8 +14,8 @@ class BaseNode:
 
     def __init__(
         self,
-        node_id: int,
-        object_dictionary: Union[ObjectDictionary, str, TextIO],
+        node_id: Optional[int],
+        object_dictionary: Union[ObjectDictionary, str, TextIO, None],
     ):
         self.network = None
 
@@ -23,4 +23,7 @@ class BaseNode:
             object_dictionary = import_od(object_dictionary, node_id)
         self.object_dictionary = object_dictionary
 
-        self.id = node_id or self.object_dictionary.node_id
+        node_id = node_id or self.object_dictionary.node_id
+        if node_id is None:
+            raise ValueError("Node ID must be specified")
+        self.id: int = node_id

--- a/canopen/node/remote.py
+++ b/canopen/node/remote.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Union, TextIO
+from typing import Union, TextIO, List, Optional
 
 from canopen.sdo import SdoClient, SdoCommunicationError, SdoAbortedError
 from canopen.nmt import NmtMaster
@@ -26,8 +26,8 @@ class RemoteNode(BaseNode):
 
     def __init__(
         self,
-        node_id: int,
-        object_dictionary: Union[ObjectDictionary, str, TextIO],
+        node_id: Optional[int],
+        object_dictionary: Union[ObjectDictionary, str, TextIO, None],
         load_od: bool = False,
     ):
         super(RemoteNode, self).__init__(node_id, object_dictionary)
@@ -35,7 +35,7 @@ class RemoteNode(BaseNode):
         #: Enable WORKAROUND for reversed PDO mapping entries
         self.curtis_hack = False
 
-        self.sdo_channels = []
+        self.sdo_channels: List[SdoClient] = []
         self.sdo = self.add_sdo(0x600 + self.id, 0x580 + self.id)
         self.tpdo = TPDO(self)
         self.rpdo = RPDO(self)

--- a/canopen/pdo/base.py
+++ b/canopen/pdo/base.py
@@ -466,8 +466,6 @@ class PdoMap:
         known to match what's stored on the node.
         """
         if self.enabled:
-            if self.pdo_node.network is None:
-               raise RuntimeError("A Network is required")
             if self.cob_id is None:
                raise RuntimeError("A valid COB-ID is required")
             logger.info("Subscribing to enabled PDO 0x%X on the network", self.cob_id)
@@ -517,8 +515,6 @@ class PdoMap:
 
     def transmit(self) -> None:
         """Transmit the message once."""
-        if self.pdo_node.network is None:
-            raise RuntimeError("A Network is required")
         if self.cob_id is None:
             raise RuntimeError("A valid COB-ID is required")
         self.pdo_node.network.send_message(self.cob_id, self.data)
@@ -531,8 +527,6 @@ class PdoMap:
             on the object before.
         :raises ValueError: When neither the argument nor the :attr:`period` is given.
         """
-        if self.pdo_node.network is None:
-            raise RuntimeError("A Network is required")
         if self.cob_id is None:
             raise RuntimeError("A valid COB-ID is required")
 
@@ -566,8 +560,6 @@ class PdoMap:
         Silently ignore if not allowed.
         """
         if self.enabled and self.rtr_allowed:
-            if self.pdo_node.network is None:
-                raise RuntimeError("A Network is required")
             if self.cob_id is None:
                 raise RuntimeError("A valid COB-ID is required")
             self.pdo_node.network.send_message(self.cob_id, bytes(), remote=True)

--- a/canopen/sdo/base.py
+++ b/canopen/sdo/base.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import binascii
-from typing import Iterator, Optional, Union
+from typing import Iterator, Optional, Union, cast
 from collections.abc import Mapping
 
 from canopen import objectdictionary
@@ -63,7 +63,7 @@ class SdoBase(Mapping):
     def __len__(self) -> int:
         return len(self.od)
 
-    def __contains__(self, key: Union[int, str]) -> bool:
+    def __contains__(self, key: object) -> bool:
         return key in self.od
 
     def get_variable(
@@ -78,6 +78,7 @@ class SdoBase(Mapping):
             return obj
         elif isinstance(obj, (SdoRecord, SdoArray)):
             return obj.get(subindex)
+        return None
 
     def upload(self, index: int, subindex: int) -> bytes:
         raise NotImplementedError()
@@ -110,7 +111,7 @@ class SdoRecord(Mapping):
     def __len__(self) -> int:
         return len(self.od)
 
-    def __contains__(self, subindex: Union[int, str]) -> bool:
+    def __contains__(self, subindex: object) -> bool:
         return subindex in self.od
 
 
@@ -130,10 +131,10 @@ class SdoArray(Mapping):
         return iter(range(1, len(self) + 1))
 
     def __len__(self) -> int:
-        return self[0].raw
+        return cast(int, self[0].raw)
 
-    def __contains__(self, subindex: int) -> bool:
-        return 0 <= subindex <= len(self)
+    def __contains__(self, subindex: object) -> bool:
+        return isinstance(subindex, int) and 0 <= subindex <= len(self)
 
 
 class SdoVariable(variable.Variable):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,3 +48,12 @@ testpaths = [
 filterwarnings = [
     "ignore::DeprecationWarning",
 ]
+
+[tool.mypy]
+files = "canopen"
+strict = "False"
+ignore_missing_imports = "True"
+disable_error_code = [
+    "annotation-unchecked",
+]
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,4 +56,3 @@ ignore_missing_imports = "True"
 disable_error_code = [
     "annotation-unchecked",
 ]
-


### PR DESCRIPTION
With reference to #358 this PR is the starting point of adding typing with mypy support in canopen. It sets a recommended permissive starting point for mypy and it contains the absolute _minimal_ code change required to pass all mypy errors.

It does contain behavioral changes that were required to pass the tests. The majority of these fixes are more graceful handling of errors that would occur anyways, so the behavioral change is what error they produce.

* Add runtime test for `self.network` before using the network
* `PeriodicMessageTask.update()` don't stop the task unless it's running
* `Variable.desc` ensure that the object is int
* `Variable.read()` fail with ValueError unless a valid fmt is used
* `Variable.write()` ensure the description is a string
* `BaseNode.__init__()` fail if no node_id is provided
* `ObjectDictionary.__getitem__()` when splitting "." only return if the object is not an `ODVariable`
* `ODRecord.__eq__()`, `ODArray.__eq__()` and `ODVariable.__eq__()` test type of other before comparing
* `ODVariable.encode_raw()`, `.decode_phys()`, `.encode_phys()` add type tests of ensure the input is of correct type
* `PdoMap` various methods: ensure necessary attributes are not None
