### PR TITLE
LocalNode improvements for TPDOs

### DIFF
--- a/canopen/nmt.py
+++ b/canopen/nmt.py
@@ -47,6 +47,15 @@ class NmtBase:
         self.id = node_id
         self.network = None
         self._state = 0
+        self._state_change_callbacks = []
+
+    def add_state_change_callback(self, callback: Callable[[str, str], None]):
+        """Add function to be called on nmt state change.
+
+        :param callback:
+            Function that should accept an old NMT state and new NMT state as arguments.
+        """
+        self._state_change_callbacks.append(callback)
 
     def on_command(self, can_id, data, timestamp):
         cmd, node_id = struct.unpack_from("BB", data)
@@ -57,6 +66,8 @@ class NmtBase:
                 if new_state != self._state:
                     logger.info("New NMT state %s, old state %s",
                                 NMT_STATES[new_state], NMT_STATES[self._state])
+                    for callback in self._state_change_callbacks:
+                        callback(old_state = NMT_STATES[self._state], new_state = NMT_STATES[new_state])
                 self._state = new_state
 
     def send_command(self, code: int):
@@ -69,6 +80,9 @@ class NmtBase:
             new_state = COMMAND_TO_STATE[code]
             logger.info("Changing NMT state on node %d from %s to %s",
                         self.id, NMT_STATES[self._state], NMT_STATES[new_state])
+            if new_state != self._state:
+                for callback in self._state_change_callbacks:
+                    callback(old_state = NMT_STATES[self._state], new_state = NMT_STATES[new_state])
             self._state = new_state
 
     @property

--- a/canopen/node/local.py
+++ b/canopen/node/local.py
@@ -34,7 +34,7 @@ class LocalNode(BaseNode):
         self.add_write_callback(self.nmt.on_write)
         self.emcy = EmcyProducer(0x80 + self.id)
 
-        self.nmt.add_state_change_callback(self.nmt_state_changed)
+        self.nmt.add_state_change_callback(self._nmt_state_changed)
 
     def associate_network(self, network):
         self.network = network
@@ -130,7 +130,7 @@ class LocalNode(BaseNode):
             obj = obj[subindex]
         return obj
 
-    def nmt_state_changed(self, old_state, new_state):
+    def _nmt_state_changed(self, old_state, new_state):
         if new_state == "OPERATIONAL":
             for i, pdo in self.tpdo.map.items():
                 if pdo.enabled:

--- a/test/test_local.py
+++ b/test/test_local.py
@@ -200,6 +200,15 @@ class TestPDO(unittest.TestCase):
         self.remote_node.pdo.save()
         self.local_node.pdo.save()
 
+    def test_send_pdo_on_operational(self):
+        self.local_node.tpdo[1].period = 0.5
+
+        self.local_node.nmt.state = 'INITIALISING'
+        self.local_node.nmt.state = 'PRE-OPERATIONAL'
+        self.local_node.nmt.state = 'OPERATIONAL'
+
+        self.assertNotEqual(self.local_node.tpdo[1]._task, None)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_local.py
+++ b/test/test_local.py
@@ -209,6 +209,28 @@ class TestPDO(unittest.TestCase):
 
         self.assertNotEqual(self.local_node.tpdo[1]._task, None)
 
+    def test_config_pdo(self):
+        # Disable tpdo 1
+        self.local_node.tpdo[1].enabled = False
+        self.local_node.tpdo[1].cob_id = 0
+        self.local_node.tpdo[1].period = 0.5 # manually assign a period
+
+        self.local_node.nmt.state = 'INITIALISING'
+        self.local_node.nmt.state = 'PRE-OPERATIONAL'
+
+        # Attempt to re-enable tpdo 1 via sdo writing
+        PDO_NOT_VALID = 1 << 31
+        odDefaultVal = self.local_node.object_dictionary["Transmit PDO 0 communication parameters.COB-ID use by TPDO 1"].default
+        enabledCobId = odDefaultVal & ~PDO_NOT_VALID # Ensure invalid bit is not set
+
+        self.remote_node.sdo["Transmit PDO 0 communication parameters.COB-ID use by TPDO 1"].raw = enabledCobId
+
+        # Transition to operational
+        self.local_node.nmt.state = 'OPERATIONAL'
+
+        # Ensure tpdo automatically started with transition
+        self.assertNotEqual(self.local_node.tpdo[1]._task, None)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Local Node improvements:
- Implement sending of TPDOs on transition to NMT operational state. #328 
- Allow runtime (pre-op) configuration of TPDO COB-ID