### PR TITLE
Fix multiple associations and removals of networks

### DIFF
--- a/canopen/network.py
+++ b/canopen/network.py
@@ -79,6 +79,9 @@ class Network(MutableMapping):
             del self.subscribers[can_id]
         else:
             self.subscribers[can_id].remove(callback)
+            # Remove empty list entry
+            if not self.subscribers[can_id]:
+                del self.subscribers[can_id]
 
     def connect(self, *args, **kwargs) -> Network:
         """Connect to CAN bus using python-can.

--- a/canopen/network.py
+++ b/canopen/network.py
@@ -75,13 +75,10 @@ class Network(MutableMapping):
             If given, remove only this callback.  Otherwise all callbacks for
             the CAN ID.
         """
-        if callback is None:
-            del self.subscribers[can_id]
-        else:
+        if callback is not None:
             self.subscribers[can_id].remove(callback)
-            # Remove empty list entry
-            if not self.subscribers[can_id]:
-                del self.subscribers[can_id]
+        if not self.subscribers[can_id] or callback is None:
+            del self.subscribers[can_id]
 
     def connect(self, *args, **kwargs) -> Network:
         """Connect to CAN bus using python-can.

--- a/canopen/node/local.py
+++ b/canopen/node/local.py
@@ -51,7 +51,6 @@ class LocalNode(BaseNode):
         network.subscribe(0, self.nmt.on_command)
 
     def remove_network(self) -> None:
-        # Make it safe to call this method multiple times
         if not self.has_network():
             return
         self.network.unsubscribe(self.sdo.rx_cobid, self.sdo.on_request)

--- a/canopen/node/local.py
+++ b/canopen/node/local.py
@@ -39,6 +39,9 @@ class LocalNode(BaseNode):
         self.emcy = EmcyProducer(0x80 + self.id)
 
     def associate_network(self, network: canopen.network.Network):
+        if self.network is not canopen.network._UNINITIALIZED_NETWORK:
+            # Unsubscribe from old network (to prevent double subscription)
+            self.remove_network()
         self.network = network
         self.sdo.network = network
         self.tpdo.network = network
@@ -49,6 +52,9 @@ class LocalNode(BaseNode):
         network.subscribe(0, self.nmt.on_command)
 
     def remove_network(self) -> None:
+        # Make it safe to call this method multiple times
+        if self.network is canopen.network._UNINITIALIZED_NETWORK:
+            return
         self.network.unsubscribe(self.sdo.rx_cobid, self.sdo.on_request)
         self.network.unsubscribe(0, self.nmt.on_command)
         self.network = canopen.network._UNINITIALIZED_NETWORK

--- a/canopen/node/local.py
+++ b/canopen/node/local.py
@@ -39,9 +39,8 @@ class LocalNode(BaseNode):
         self.emcy = EmcyProducer(0x80 + self.id)
 
     def associate_network(self, network: canopen.network.Network):
-        if self.network is not canopen.network._UNINITIALIZED_NETWORK:
-            # Unsubscribe from old network (to prevent double subscription)
-            self.remove_network()
+        if self.has_network():
+            raise RuntimeError("Node is already associated with a network")
         self.network = network
         self.sdo.network = network
         self.tpdo.network = network
@@ -53,7 +52,7 @@ class LocalNode(BaseNode):
 
     def remove_network(self) -> None:
         # Make it safe to call this method multiple times
-        if self.network is canopen.network._UNINITIALIZED_NETWORK:
+        if not self.has_network():
             return
         self.network.unsubscribe(self.sdo.rx_cobid, self.sdo.on_request)
         self.network.unsubscribe(0, self.nmt.on_command)

--- a/canopen/node/remote.py
+++ b/canopen/node/remote.py
@@ -66,7 +66,6 @@ class RemoteNode(BaseNode):
         network.subscribe(0, self.nmt.on_command)
 
     def remove_network(self) -> None:
-        # Make it safe to call this method multiple times
         if not self.has_network():
             return
         for sdo in self.sdo_channels:

--- a/canopen/node/remote.py
+++ b/canopen/node/remote.py
@@ -51,9 +51,8 @@ class RemoteNode(BaseNode):
             self.load_configuration()
 
     def associate_network(self, network: canopen.network.Network):
-        if self.network is not canopen.network._UNINITIALIZED_NETWORK:
-            # Unsubscribe from old network (to prevent double subscriptions)
-            self.remove_network()
+        if self.has_network():
+            raise RuntimeError("Node is already associated with a network")
         self.network = network
         self.sdo.network = network
         self.pdo.network = network
@@ -68,7 +67,7 @@ class RemoteNode(BaseNode):
 
     def remove_network(self) -> None:
         # Make it safe to call this method multiple times
-        if self.network is canopen.network._UNINITIALIZED_NETWORK:
+        if not self.has_network():
             return
         for sdo in self.sdo_channels:
             self.network.unsubscribe(sdo.tx_cobid, sdo.on_response)

--- a/test/test_node.py
+++ b/test/test_node.py
@@ -1,20 +1,14 @@
-"""Unit tests for the RemoteNode and LocalNode classes."""
 import unittest
 
 import canopen
-import canopen.network
-import canopen.objectdictionary
 
 
 def count_subscribers(network: canopen.Network) -> int:
     """Count the number of subscribers in the network."""
-    return sum(
-        len(n) for n in network.subscribers.values()
-    )
+    return sum(len(n) for n in network.subscribers.values())
 
 
 class TestLocalNode(unittest.TestCase):
-    """Unit tests for the LocalNode class."""
 
     @classmethod
     def setUpClass(cls):
@@ -29,7 +23,6 @@ class TestLocalNode(unittest.TestCase):
         cls.network.disconnect()
 
     def test_associate_network(self):
-
         # Need to store the number of subscribers before associating because the
         # network implementation automatically adds subscribers to the list
         n_subscribers = count_subscribers(self.network)
@@ -65,7 +58,6 @@ class TestLocalNode(unittest.TestCase):
 
 
 class TestRemoteNode(unittest.TestCase):
-    """Unittests for the RemoteNode class."""
 
     @classmethod
     def setUpClass(cls):
@@ -80,7 +72,6 @@ class TestRemoteNode(unittest.TestCase):
         cls.network.disconnect()
 
     def test_associate_network(self):
-
         # Need to store the number of subscribers before associating because the
         # network implementation automatically adds subscribers to the list
         n_subscribers = count_subscribers(self.network)

--- a/test/test_node.py
+++ b/test/test_node.py
@@ -2,6 +2,7 @@
 import unittest
 
 import canopen
+import canopen.network
 
 from .util import SAMPLE_EDS
 
@@ -14,15 +15,13 @@ def count_subscribers(network: canopen.Network) -> int:
 
 
 class TestLocalNode(unittest.TestCase):
-    """
-    Test local node.
-    """
+    """Unit tests for the LocalNode class."""
 
     @classmethod
     def setUpClass(cls):
         cls.network = canopen.Network()
         cls.network.NOTIFIER_SHUTDOWN_TIMEOUT = 0.0
-        cls.network.connect("test", interface="virtual")
+        cls.network.connect(interface="virtual")
 
         cls.node = canopen.LocalNode(2, SAMPLE_EDS)
 
@@ -46,11 +45,10 @@ class TestLocalNode(unittest.TestCase):
         self.assertIs(self.node.nmt.network, self.network)
         self.assertIs(self.node.emcy.network, self.network)
 
-        # Test that its possible to associate the network multiple times
-        # by checking that the number of subscribers remains the same
-        count = count_subscribers(self.network)
-        self.node.associate_network(self.network)
-        self.assertEqual(count_subscribers(self.network), count)
+        # Test that its not possible to associate the network multiple times
+        with self.assertRaises(RuntimeError) as cm:
+            self.node.associate_network(self.network)
+        self.assertIn("already associated with a network", str(cm.exception))
 
         # Test removal of the network. The count of subscribers should
         # be the same as before the association
@@ -69,15 +67,13 @@ class TestLocalNode(unittest.TestCase):
 
 
 class TestRemoteNode(unittest.TestCase):
-    """
-    Test remote node.
-    """
+    """Unittests for the RemoteNode class."""
 
     @classmethod
     def setUpClass(cls):
         cls.network = canopen.Network()
         cls.network.NOTIFIER_SHUTDOWN_TIMEOUT = 0.0
-        cls.network.connect("test", interface="virtual")
+        cls.network.connect(interface="virtual")
 
         cls.node = canopen.RemoteNode(2, SAMPLE_EDS)
 
@@ -100,11 +96,10 @@ class TestRemoteNode(unittest.TestCase):
         self.assertIs(self.node.rpdo.network, self.network)
         self.assertIs(self.node.nmt.network, self.network)
 
-        # Test that its possible to associate the network multiple times
-        # by checking that the number of subscribers remains the same
-        count = count_subscribers(self.network)
-        self.node.associate_network(self.network)
-        self.assertEqual(count_subscribers(self.network), count)
+        # Test that its not possible to associate the network multiple times
+        with self.assertRaises(RuntimeError) as cm:
+            self.node.associate_network(self.network)
+        self.assertIn("already associated with a network", str(cm.exception))
 
         # Test removal of the network. The count of subscribers should
         # be the same as before the association

--- a/test/test_node.py
+++ b/test/test_node.py
@@ -1,0 +1,121 @@
+"""Unit tests for the RemoteNode and LocalNode classes."""
+import unittest
+
+import canopen
+
+from .util import SAMPLE_EDS
+
+
+def count_subscribers(network: canopen.Network) -> int:
+    """Count the number of subscribers in the network."""
+    return sum(
+        len(n) for n in network.subscribers.values()
+    )
+
+
+class TestLocalNode(unittest.TestCase):
+    """
+    Test local node.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.network = canopen.Network()
+        cls.network.NOTIFIER_SHUTDOWN_TIMEOUT = 0.0
+        cls.network.connect("test", interface="virtual")
+
+        cls.node = canopen.LocalNode(2, SAMPLE_EDS)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.network.disconnect()
+
+    def test_associate_network(self):
+
+        # Need to store the number of subscribers before associating because
+        # the current network implementation automatically adds subscribers
+        # to the list
+        n_subscribers = count_subscribers(self.network)
+
+        # Associating the network with the local node
+        self.node.associate_network(self.network)
+        self.assertIs(self.node.network, self.network)
+        self.assertIs(self.node.sdo.network, self.network)
+        self.assertIs(self.node.tpdo.network, self.network)
+        self.assertIs(self.node.rpdo.network, self.network)
+        self.assertIs(self.node.nmt.network, self.network)
+        self.assertIs(self.node.emcy.network, self.network)
+
+        # Test that its possible to associate the network multiple times
+        # by checking that the number of subscribers remains the same
+        count = count_subscribers(self.network)
+        self.node.associate_network(self.network)
+        self.assertEqual(count_subscribers(self.network), count)
+
+        # Test removal of the network. The count of subscribers should
+        # be the same as before the association
+        self.node.remove_network()
+        uninitalized = canopen.network._UNINITIALIZED_NETWORK
+        self.assertIs(self.node.network, uninitalized)
+        self.assertIs(self.node.sdo.network, uninitalized)
+        self.assertIs(self.node.tpdo.network, uninitalized)
+        self.assertIs(self.node.rpdo.network, uninitalized)
+        self.assertIs(self.node.nmt.network, uninitalized)
+        self.assertIs(self.node.emcy.network, uninitalized)
+        self.assertEqual(count_subscribers(self.network), n_subscribers)
+
+        # Test that its possible to deassociate the network multiple times
+        self.node.remove_network()
+
+
+class TestRemoteNode(unittest.TestCase):
+    """
+    Test remote node.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.network = canopen.Network()
+        cls.network.NOTIFIER_SHUTDOWN_TIMEOUT = 0.0
+        cls.network.connect("test", interface="virtual")
+
+        cls.node = canopen.RemoteNode(2, SAMPLE_EDS)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.network.disconnect()
+
+    def test_associate_network(self):
+
+        # Need to store the number of subscribers before associating because
+        # the current network implementation automatically adds subscribers
+        # to the list
+        n_subscribers = count_subscribers(self.network)
+
+        # Associating the network with the local node
+        self.node.associate_network(self.network)
+        self.assertIs(self.node.network, self.network)
+        self.assertIs(self.node.sdo.network, self.network)
+        self.assertIs(self.node.tpdo.network, self.network)
+        self.assertIs(self.node.rpdo.network, self.network)
+        self.assertIs(self.node.nmt.network, self.network)
+
+        # Test that its possible to associate the network multiple times
+        # by checking that the number of subscribers remains the same
+        count = count_subscribers(self.network)
+        self.node.associate_network(self.network)
+        self.assertEqual(count_subscribers(self.network), count)
+
+        # Test removal of the network. The count of subscribers should
+        # be the same as before the association
+        self.node.remove_network()
+        uninitalized = canopen.network._UNINITIALIZED_NETWORK
+        self.assertIs(self.node.network, uninitalized)
+        self.assertIs(self.node.sdo.network, uninitalized)
+        self.assertIs(self.node.tpdo.network, uninitalized)
+        self.assertIs(self.node.rpdo.network, uninitalized)
+        self.assertIs(self.node.nmt.network, uninitalized)
+        self.assertEqual(count_subscribers(self.network), n_subscribers)
+
+        # Test that its possible to deassociate the network multiple times
+        self.node.remove_network()

--- a/test/test_node.py
+++ b/test/test_node.py
@@ -3,8 +3,7 @@ import unittest
 
 import canopen
 import canopen.network
-
-from .util import SAMPLE_EDS
+import canopen.objectdictionary
 
 
 def count_subscribers(network: canopen.Network) -> int:
@@ -23,7 +22,7 @@ class TestLocalNode(unittest.TestCase):
         cls.network.NOTIFIER_SHUTDOWN_TIMEOUT = 0.0
         cls.network.connect(interface="virtual")
 
-        cls.node = canopen.LocalNode(2, SAMPLE_EDS)
+        cls.node = canopen.LocalNode(2, canopen.objectdictionary.ObjectDictionary())
 
     @classmethod
     def tearDownClass(cls):
@@ -31,9 +30,8 @@ class TestLocalNode(unittest.TestCase):
 
     def test_associate_network(self):
 
-        # Need to store the number of subscribers before associating because
-        # the current network implementation automatically adds subscribers
-        # to the list
+        # Need to store the number of subscribers before associating because the
+        # network implementation automatically adds subscribers to the list
         n_subscribers = count_subscribers(self.network)
 
         # Associating the network with the local node
@@ -75,7 +73,7 @@ class TestRemoteNode(unittest.TestCase):
         cls.network.NOTIFIER_SHUTDOWN_TIMEOUT = 0.0
         cls.network.connect(interface="virtual")
 
-        cls.node = canopen.RemoteNode(2, SAMPLE_EDS)
+        cls.node = canopen.RemoteNode(2, canopen.objectdictionary.ObjectDictionary())
 
     @classmethod
     def tearDownClass(cls):
@@ -83,9 +81,8 @@ class TestRemoteNode(unittest.TestCase):
 
     def test_associate_network(self):
 
-        # Need to store the number of subscribers before associating because
-        # the current network implementation automatically adds subscribers
-        # to the list
+        # Need to store the number of subscribers before associating because the
+        # network implementation automatically adds subscribers to the list
         n_subscribers = count_subscribers(self.network)
 
         # Associating the network with the local node


### PR DESCRIPTION
This PR fixes the issue of not being able to call `associate_network()` and `remove_network()` multiple times. See #562.

Fixes #562