### PR TITLE
Prevent warnings if SDO setup fails

### DIFF
--- a/canopen/sdo/client.py
+++ b/canopen/sdo/client.py
@@ -669,6 +669,8 @@ class BlockDownloadStream(io.RawIOBase):
         self._blksize, = struct.unpack_from("B", response, 4)
         logger.debug("Server requested a block size of %d", self._blksize)
         self.crc_supported = bool(res_command & CRC_SUPPORTED)
+        # Run this last, used later to determine if initialization was successful
+        self._initialized = True
 
     def write(self, b):
         """
@@ -784,6 +786,9 @@ class BlockDownloadStream(io.RawIOBase):
         if self.closed:
             return
         super(BlockDownloadStream, self).close()
+        if not hasattr(self, "_initialized"):
+            # Don't do finalization if initialization was not successful
+            return
         if not self._done:
             logger.error("Block transfer was not finished")
         command = REQUEST_BLOCK_DOWNLOAD | END_BLOCK_TRANSFER

--- a/canopen/sdo/server.py
+++ b/canopen/sdo/server.py
@@ -120,6 +120,10 @@ class SdoServer(SdoBase):
 
     def block_download(self, data):
         # We currently don't support BLOCK DOWNLOAD
+        # Unpack the index and subindex in order to send appropriate abort
+        command, index, subindex = SDO_STRUCT.unpack_from(data)
+        self._index = index
+        self._subindex = subindex
         logger.error("Block download is not supported")
         self.abort(0x05040001)
 


### PR DESCRIPTION
The test `test_block_download_not_supported` is creating warnings from pytest

```
test/test_local.py::TestSDO::test_block_download_not_supported
  C:\Svein\canopen\venv\Lib\site-packages\_pytest\unraisableexception.py:85: PytestUnraisableExceptionWarning: Exception ignored in: <canopen.sdo.client.BlockDownloadStream object at 0x000001DA52BA6350>

  canopen.sdo.exceptions.SdoAbortedError: Code 0x05040001, Unknown SDO command specified

  During handling of the above exception, another exception occurred:

  Traceback (most recent call last):
    File "C:\Svein\canopen\canopen\sdo\client.py", line 794, in close
      if self.crc_supported:
         ^^^^^^^^^^^^^^^^^^
  AttributeError: 'BlockDownloadStream' object has no attribute 'crc_supported'
```

https://github.com/canopen-python/canopen/blob/7ddb19b2ca7b7a85b9cef3090249b00293dd4b4a/test/test_local.py#L48-L55

This PR fixes the issue. The problem was 2-fold.

- The test tries to use a block download, which `SdoServer.block_download()` handles by sending an SDO abort. However, sending the abort fails, because `SdoServer.abort()` requires `self._index` and `self._subindex`.
- The SdoClient.open() opens a `BlockDownloadStream()`, but it doesn't get to initialize fully before the effort is aborted. When the object is closed, it fails as it's left in limbo.