### PR TITLE
Disregard OD variable description in SdoClient.upload()

### DIFF
--- a/canopen/objectdictionary/__init__.py
+++ b/canopen/objectdictionary/__init__.py
@@ -419,6 +419,12 @@ class ODVariable:
         """
         self.bit_definitions[name] = bits
 
+    @property
+    def fixed_size(self) -> bool:
+        """Indicate whether the amount of needed data is known in advance."""
+        # Only for types which we parse using a structure.
+        return self.data_type in self.STRUCT_TYPES
+
     def decode_raw(self, data: bytes) -> Union[int, float, str, bytes, bytearray]:
         if self.data_type == VISIBLE_STRING:
             # Strip any trailing NUL characters from C-based systems

--- a/canopen/sdo/base.py
+++ b/canopen/sdo/base.py
@@ -148,7 +148,18 @@ class SdoVariable(variable.Variable):
         variable.Variable.__init__(self, od)
 
     def get_data(self) -> bytes:
-        return self.sdo_node.upload(self.od.index, self.od.subindex)
+        data = self.sdo_node.upload(self.od.index, self.od.subindex)
+        response_size = len(data)
+
+        # If size is available through variable in OD, then use the smaller of the two sizes.
+        # Some devices send U32/I32 even if variable is smaller in OD
+        if self.od.fixed_size:
+            # Get the size in bytes for this variable
+            var_size = len(self.od) // 8
+            if response_size is None or var_size < response_size:
+                # Truncate the data to specified size
+                data = data[0:var_size]
+        return data
 
     def set_data(self, data: bytes):
         force_segment = self.od.data_type == objectdictionary.DOMAIN

--- a/canopen/sdo/client.py
+++ b/canopen/sdo/client.py
@@ -126,9 +126,7 @@ class SdoClient(SdoBase):
         var = self.od.get_variable(index, subindex)
         if var is not None:
             # Found a matching variable in OD
-            # If this is a data type (string, domain etc) the size is
-            # unknown anyway so keep the data as is
-            if var.data_type not in objectdictionary.DATA_TYPES:
+            if var.fixed_size:
                 # Get the size in bytes for this variable
                 var_size = len(var) // 8
                 if response_size is None or var_size < response_size:

--- a/canopen/sdo/client.py
+++ b/canopen/sdo/client.py
@@ -105,6 +105,10 @@ class SdoClient(SdoBase):
     def upload(self, index: int, subindex: int) -> bytes:
         """May be called to make a read operation without an Object Dictionary.
 
+        No validation against the Object Dictionary is performed, even if an object description
+        would be available.  The length of the returned data depends only on the transferred
+        amount, possibly truncated to the size indicated by the server.
+
         :param index:
             Index of object to read.
         :param subindex:
@@ -121,17 +125,8 @@ class SdoClient(SdoBase):
             response_size = fp.size
             data = fp.read()
 
-        # If size is available through variable in OD, then use the smaller of the two sizes.
-        # Some devices send U32/I32 even if variable is smaller in OD
-        var = self.od.get_variable(index, subindex)
-        if var is not None:
-            # Found a matching variable in OD
-            if var.fixed_size:
-                # Get the size in bytes for this variable
-                var_size = len(var) // 8
-                if response_size is None or var_size < response_size:
-                    # Truncate the data to specified size
-                    data = data[0:var_size]
+        if response_size and response_size < len(data):
+            data = data[:response_size]
         return data
 
     def download(

--- a/test/test_sdo.py
+++ b/test/test_sdo.py
@@ -814,7 +814,6 @@ class TestSDOClientDatatypes(unittest.TestCase):
 
     def test_unknown_datatype32(self):
         """Test an unknown datatype, but known OD, of 32 bits (4 bytes)."""
-        return  # FIXME: Disabled temporarily until datatype conditionals are fixed, see #436
         # Add fake entry 0x2100 to OD, using fake datatype 0xFF
         if 0x2100 not in self.node.object_dictionary:
             fake_var = ODVariable("Fake", 0x2100)
@@ -829,7 +828,6 @@ class TestSDOClientDatatypes(unittest.TestCase):
 
     def test_unknown_datatype112(self):
         """Test an unknown datatype, but known OD, of 112 bits (14 bytes)."""
-        return  # FIXME: Disabled temporarily until datatype conditionals are fixed, see #436
         # Add fake entry 0x2100 to OD, using fake datatype 0xFF
         if 0x2100 not in self.node.object_dictionary:
             fake_var = ODVariable("Fake", 0x2100)

--- a/test/test_sdo.py
+++ b/test/test_sdo.py
@@ -102,9 +102,9 @@ class TestSDO(unittest.TestCase):
             (TX, b'\x40\x00\x14\x02\x00\x00\x00\x00'),
             (RX, b'\x42\x00\x14\x02\xfe\x00\x00\x00')
         ]
-        # Make sure the size of the data is 1 byte
+        # This method used to truncate to 1 byte, but returns raw content now
         data = self.network[2].sdo.upload(0x1400, 2)
-        self.assertEqual(data, b'\xfe')
+        self.assertEqual(data, b'\xfe\x00\x00\x00')
         self.assertTrue(self.message_sent)
 
     def test_expedited_download(self):


### PR DESCRIPTION
The upload method should behave as a raw producer of byte data.
Interpretation of the returned data based on the Object Dictionary is
the responsibility of the `SdoVariable` class, which delegates to the
generic `ODVariable` decoding functions.

Move the data truncation to the method `SdoVariable.get_data()`, where
access to the `ODVariable` is certain.

The only truncation that still happens is based on the response size
specified by the server, which might be smaller for e.g. expedited
upload.  Extend the `upload()` function docstring to clarify the changed
behavior.  Adjust the test case for expedited upload with unspecified
size in the response, which is the only incompatible change.

This is based on, and includes the changes of, #591.