### PR TITLE
sdo.client: Add missing abort messages

### DIFF
--- a/canopen/sdo/client.py
+++ b/canopen/sdo/client.py
@@ -93,7 +93,7 @@ class SdoClient(SdoBase):
                     raise
                 logger.warning(str(e))
 
-    def abort(self, abort_code=0x08000000):
+    def abort(self, abort_code=0x0800_0000):
         """Abort current transfer."""
         request = bytearray(8)
         request[0] = REQUEST_ABORTED

--- a/canopen/sdo/client.py
+++ b/canopen/sdo/client.py
@@ -69,6 +69,7 @@ class SdoClient(SdoBase):
             response = self.responses.get(
                 block=True, timeout=self.RESPONSE_TIMEOUT)
         except queue.Empty:
+            self.abort(0x05040000)
             raise SdoCommunicationError("No SDO response received")
         res_command, = struct.unpack_from("B", response)
         if res_command == RESPONSE_ABORTED:
@@ -364,6 +365,7 @@ class WritableStream(io.RawIOBase):
             response = sdo_client.request_response(request)
             res_command, = struct.unpack_from("B", response)
             if res_command != RESPONSE_DOWNLOAD:
+                self.sdo_client.abort(0x05040001)
                 raise SdoCommunicationError(
                     f"Unexpected response 0x{res_command:02X}")
         else:
@@ -392,6 +394,7 @@ class WritableStream(io.RawIOBase):
             response = self.sdo_client.request_response(request)
             res_command, = struct.unpack_from("B", response)
             if res_command & 0xE0 != RESPONSE_DOWNLOAD:
+                self.sdo_client.abort(0x05040001)
                 raise SdoCommunicationError(
                     f"Unexpected response 0x{res_command:02X}")
             bytes_sent = len(b)
@@ -416,6 +419,7 @@ class WritableStream(io.RawIOBase):
             response = self.sdo_client.request_response(request)
             res_command, = struct.unpack("B", response[0:1])
             if res_command & 0xE0 != RESPONSE_SEGMENT_DOWNLOAD:
+                self.sdo_client.abort(0x05040001)
                 raise SdoCommunicationError(
                     f"Unexpected response 0x{res_command:02X} "
                     f"(expected 0x{RESPONSE_SEGMENT_DOWNLOAD:02X})")

--- a/canopen/sdo/client.py
+++ b/canopen/sdo/client.py
@@ -571,7 +571,7 @@ class BlockUploadStream(io.RawIOBase):
                 return response
         self._error = True
         self.sdo_client.abort(0x0504_0000)
-        raise SdoCommunicationError("Some data were lost and could not be retransmitted")
+        raise SdoCommunicationError("Some data was lost and could not be retransmitted")
 
     def _ack_block(self):
         request = bytearray(8)

--- a/canopen/sdo/client.py
+++ b/canopen/sdo/client.py
@@ -65,6 +65,13 @@ class SdoClient(SdoBase):
                 break
 
     def read_response(self):
+        """Wait for an SDO response and handle timeout or remote abort.
+
+        :raises canopen.SdoAbortedError:
+            When receiving an SDO abort response from the server.
+        :raises canopen.SdoCommunicationError:
+            After timeout with no response received.
+        """
         try:
             response = self.responses.get(
                 block=True, timeout=self.RESPONSE_TIMEOUT)

--- a/canopen/sdo/client.py
+++ b/canopen/sdo/client.py
@@ -302,8 +302,10 @@ class ReadableStream(io.RawIOBase):
         response = self.sdo_client.request_response(request)
         res_command, = struct.unpack_from("B", response)
         if res_command & 0xE0 != RESPONSE_SEGMENT_UPLOAD:
+            self.sdo_client.abort(0x05040001)
             raise SdoCommunicationError(f"Unexpected response 0x{res_command:02X}")
         if res_command & TOGGLE_BIT != self._toggle:
+            self.sdo_client.abort(0x05030000)
             raise SdoCommunicationError("Toggle bit mismatch")
         length = 7 - ((res_command >> 1) & 0x7)
         if res_command & NO_MORE_DATA:


### PR DESCRIPTION
SDO abort messages were sent in some cases when a response times out or has an unexpected server command specifier.  But not consistently, thus the following cases are now added:

* Mismatched scs:
  * ReadableStream, after upload segment request
  * WritableStream, after download initiate request
  * WritableStream, after expedited download request
  * WritableStream, after download segment request

* Toggle bit mismatch (reports as not toggled):
  * ReadableStream, after upload segment request

Some reformatting of abort code literals squeezed in there, as well as a typo fix.

This is based on the changes in #352, isolated from the typing noise.