### PR TITLE
sync: Prevent from starting periodic task when already running (fixes #582)

### DIFF
--- a/canopen/sync.py
+++ b/canopen/sync.py
@@ -32,6 +32,9 @@ class SyncProducer:
         :param period:
             Period of SYNC message in seconds.
         """
+        if self._task is not None:
+            raise RuntimeError("Periodic SYNC transmission task already running")
+
         if period is not None:
             self.period = period
 
@@ -44,3 +47,4 @@ class SyncProducer:
         """Stop periodic transmission of SYNC message."""
         if self._task is not None:
             self._task.stop()
+        self._task = None

--- a/test/test_sync.py
+++ b/test/test_sync.py
@@ -74,6 +74,16 @@ class TestSync(unittest.TestCase):
         if msg is not None:
             self.assertIsNone(self.net.bus.recv(TIMEOUT))
 
+    def test_sync_producer_restart(self):
+        self.sync.start(PERIOD)
+        self.addCleanup(self.sync.stop)
+        # Cannot start again while running
+        with self.assertRaises(RuntimeError):
+            self.sync.start(PERIOD)
+        # Can restart after stopping
+        self.sync.stop()
+        self.sync.start(PERIOD)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Raise a RuntimeError when a SYNC transmission task has previously been
started.  Make sure to clear the internal _task attribute when
stopping, to make the check work.