### PR TITLE
NmtMaster: Delay heartbeat callbacks after state update (fixes #579)

### DIFF
--- a/canopen/nmt.py
+++ b/canopen/nmt.py
@@ -120,14 +120,13 @@ class NmtMaster(NmtBase):
         self._callbacks: List[Callable[[int], None]] = []
 
     def on_heartbeat(self, can_id, data, timestamp):
+        new_state, = struct.unpack_from("B", data)
+        # Mask out toggle bit
+        new_state &= 0x7F
+        logger.debug("Received heartbeat can-id %d, state is %d", can_id, new_state)
+
         with self.state_update:
             self.timestamp = timestamp
-            new_state, = struct.unpack_from("B", data)
-            # Mask out toggle bit
-            new_state &= 0x7F
-            logger.debug("Received heartbeat can-id %d, state is %d", can_id, new_state)
-            for callback in self._callbacks:
-                callback(new_state)
             if new_state == 0:
                 # Boot-up, will go to PRE-OPERATIONAL automatically
                 self._state = 127
@@ -135,6 +134,9 @@ class NmtMaster(NmtBase):
                 self._state = new_state
             self._state_received = new_state
             self.state_update.notify_all()
+
+        for callback in self._callbacks:
+            callback(new_state)
 
     def send_command(self, code: int):
         """Send an NMT command code to the node.


### PR DESCRIPTION
Reduce the amount of code within the critical section holding the lock.  Unpack and log first.  Update timestamp and state while locked and notify condition waiters.  Invoke callbacks after releasing the lock.

Based on the suggestion in https://github.com/canopen-python/canopen/issues/579#issuecomment-2849418086, just without the added callback argument and without using a `call()` wrapper yet.