### PR TITLE
build: Fix package auto-discovery (ref #468)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,8 +35,8 @@ db_export = [
 documentation = "https://canopen.readthedocs.io/en/stable/"
 repository = "https://github.com/canopen-python/canopen"
 
-[tool.setuptools]
-packages = ["canopen"]
+[tool.setuptools.packages.find]
+include = ["canopen", "canopen.*"]
 
 [tool.setuptools_scm]
 version_file = "canopen/_version.py"


### PR DESCRIPTION
Commit 1fc63b5f4835eba80462c7892a2cd00f786ec9ce tried to limit the built packages to ignore other arbitrary top-level directories.  But in turn, it disabled the auto-discovery in setuptools completely. This results in build warnings for the missing sub-packages that would have been auto-discovered.

Switch to an explicit setuptools.packages.find configuration which still limits to the canopen top-level package.