### PR TITLE
build: Bump minimum Python version to 3.9 and update license metadata (fixes #585)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ The aim of the project is to support the most common parts of the CiA 301
 standard in a simple Pythonic interface. It is mainly targeted for testing and
 automation tasks rather than a standard compliant master implementation.
 
-The library supports Python 3.8 or newer.
+The library supports Python 3.9 or newer.
 
 
 Features

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=69", "wheel", "setuptools_scm>=8"]
+requires = ["setuptools>=77", "wheel", "setuptools_scm>=8"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -11,11 +11,11 @@ authors = [
 ]
 description = "CANopen stack implementation"
 readme = "README.rst"
-requires-python = ">=3.8"
-license = {file = "LICENSE.txt"}
+requires-python = ">=3.9"
+license = "MIT"
+license-files = ["LICENSE.txt"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
-    "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3 :: Only",
     "Intended Audience :: Developers",
@@ -50,7 +50,7 @@ filterwarnings = [
 ]
 
 [tool.mypy]
-python_version = "3.8"
+python_version = "3.9"
 exclude = [
     "^examples*",
     "^test*",


### PR DESCRIPTION
Avoid deprecation warnings with modern setuptools, which will stop supporting a table as the project.license option in pyproject.toml soon.  Require a modern version >= 77 to make use of the alternative options.