### PR TITLE
Use integer division in encode_phys to prevent rounding errors with int64

### DIFF
--- a/canopen/objectdictionary/__init__.py
+++ b/canopen/objectdictionary/__init__.py
@@ -484,8 +484,12 @@ class ODVariable:
 
     def encode_phys(self, value: Union[int, bool, float, str, bytes]) -> int:
         if self.data_type in INTEGER_TYPES:
-            value /= self.factor
-            value = int(round(value))
+            if self.factor == 1:
+                pass
+            elif isinstance(value, int) and isinstance(self.factor, int):
+                value = value // self.factor
+            else:
+                value = int(round(value / self.factor))
         return value
 
     def decode_desc(self, value: int) -> str:


### PR DESCRIPTION
While testing `int64` values with SDOs, I observed an unexpected behavior:

```python
>>> value = 0x55554444AAAABBBB
>>> d.node.sdo[16384][4].phys = value
>>> hex(d.node.sdo[16384][4].phys)
'0x55554444aaaabc00'
```

Upon investigation, it appears that the issue originates from the `encode_phys` function:

```python
>>> value = 0x55554444AAAABBBB
>>> sdo.od.factor
1
>>> hex(sdo.od.encode_phys(value))
'0x55554444aaaabc00'
```

The problem lies in the fact that the division is performed using floating-point arithmetic rather than integer arithmetic, leading to rounding that causes a loss of up to 10 bits of precision.

```python
def encode_phys(self, value: Union[int, bool, float, str, bytes]) -> int:
    if self.data_type in INTEGER_TYPES:
        value /= self.factor
        value = int(round(value))
    return value
```

To address this, we should detect whether the input value is an integer and, if so, perform integer division (`//`) instead of floating-point division. Additionally, it may be prudent to emit a warning when `factor` is not an integer, as this could lead to precision loss.
