### PR TITLE
Custom Options for EDS file

### DIFF
--- a/canopen/objectdictionary/__init__.py
+++ b/canopen/objectdictionary/__init__.py
@@ -209,6 +209,8 @@ class ODRecord(MutableMapping):
         self.storage_location = None
         self.subindices = {}
         self.names = {}
+        #: Key-Value pairs not defined by the standard
+        self.custom_options = {}
 
     def __repr__(self) -> str:
         return f"<{type(self).__qualname__} {self.name!r} at {pretty_index(self.index)}>"
@@ -268,6 +270,8 @@ class ODArray(Mapping):
         self.storage_location = None
         self.subindices = {}
         self.names = {}
+        #: Key-Value pairs not defined by the standard
+        self.custom_options = {}
 
     def __repr__(self) -> str:
         return f"<{type(self).__qualname__} {self.name!r} at {pretty_index(self.index)}>"
@@ -374,6 +378,8 @@ class ODVariable:
         self.storage_location = None
         #: Can this variable be mapped to a PDO
         self.pdo_mappable = False
+        #: Key-Value pairs not defined by the standard
+        self.custom_options = {}
 
     def __repr__(self) -> str:
         subindex = self.subindex if isinstance(self.parent, (ODRecord, ODArray)) else None

--- a/canopen/objectdictionary/eds.py
+++ b/canopen/objectdictionary/eds.py
@@ -131,7 +131,6 @@ def import_eds(source, node_id):
 
             if object_type in (VAR, DOMAIN):
                 var = build_variable(eds, section, node_id, index)
-                var.custom_options = _get_custom_options(eds, section)
                 od.add_object(var)
             elif object_type == ARR and eds.has_option(section, "CompactSubObj"):
                 arr = objectdictionary.ODArray(name, index)
@@ -257,15 +256,16 @@ def _revert_variable(var_type, value):
     else:
         return f"0x{value:02X}"
 
-_STANDARD_OPTIONS = ["ObjectType"      , "ParameterName" , "DataType"    , "AccessType"   ,
-                     "PDOMapping"      , "LowLimit"      , "HighLimit"   , "DefaultValue" ,
-                     "ParameterValue"  , "Factor"        , "Description" , "Unit"         ,
-                     "StorageLocation" , "CompactSubObj"                                  ]
+_STANDARD_OPTIONS = ["objecttype"      , "parametername" , "datatype"    , "accesstype"   ,
+                     "pdomapping"      , "lowlimit"      , "highlimit"   , "defaultvalue" ,
+                     "parametervalue"  , "factor"        , "description" , "unit"         ,
+                     "storagelocation" , "compactsubobj" , "nrofentries" , "subnumber"    ,
+                     "objflags"        , "denotation"                                     ]
 
 def _get_custom_options(eds, section):
     custom_options = {}
     for option, value in eds.items(section):
-        if option not in _STANDARD_OPTIONS:
+        if not (option.lower() in _STANDARD_OPTIONS or option.isdigit()) :
             custom_options[option] = value
     return custom_options
 
@@ -521,19 +521,19 @@ def export_eds(od, dest=None, file_info={}, device_commisioning=False):
     def mandatory_indices(x):
         return x in {0x1000, 0x1001, 0x1018}
 
-    def manufacturer_indices(x):
-        return 0x2000 <= x < 0x6000
+    def manufacturer_idices(x):
+        return x in range(0x2000, 0x6000)
 
     def optional_indices(x):
         return all((
             x > 0x1001,
             not mandatory_indices(x),
-            not manufacturer_indices(x),
+            not manufacturer_idices(x),
         ))
 
     supported_mantatory_indices = list(filter(mandatory_indices, od))
     supported_optional_indices = list(filter(optional_indices, od))
-    supported_manufacturer_indices = list(filter(manufacturer_indices, od))
+    supported_manufacturer_indices = list(filter(manufacturer_idices, od))
 
     def add_list(section, list):
         eds.add_section(section)


### PR DESCRIPTION
Vector CANeds tool groups all unknown options contained in an EDS File in a dedicated section called "Unknown Entries".
We use that section to save additional information that is not considered by the CANopen specifications (for example: unit, factor, offset, category, etc.), and so I had to modify this library to read and write those options.

If you open a file that contains unknown option names, they will be grouped in the "custom_options" dictionary.
If you desire to save a value with a specific option name, you can update the "custom_options" dictionary accordingly.

P.S.: In the meantime, I've improved some of the bad code.