### PR TITLE
Add venv/ and .venv/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ __pycache__/
 # Distribution / packaging
 .Python
 env/
+venv/
+.venv/
 build/
 develop-eggs/
 dist/


### PR DESCRIPTION
Add `venv/` and `.venv/` directories to `.gitignore` so that local virtual environments are not accidentally tracked.