### PR TITLE
Fix encode_phys precision loss for int64 with factor=1

### DIFF
--- a/canopen/objectdictionary/__init__.py
+++ b/canopen/objectdictionary/__init__.py
@@ -484,8 +484,8 @@ class ODVariable:
 
     def encode_phys(self, value: Union[int, bool, float, str, bytes]) -> int:
         if self.data_type in INTEGER_TYPES:
-            value /= self.factor
-            value = int(round(value))
+            if self.factor != 1:
+                value = round(value / self.factor)
         return value
 
     def decode_desc(self, value: int) -> str:

--- a/test/test_od.py
+++ b/test/test_od.py
@@ -196,7 +196,7 @@ class TestAlternativeRepresentations(unittest.TestCase):
         self.assertIsInstance(var.encode_phys(42), int)
 
     def test_phys_factor_1000_rounds(self):
-        """Existing rounding behaviour with integer factor != 1 is preserved."""
+        """Integer factor > 1 uses float rounding behaviour, not truncating division."""
         var = od.ODVariable("Test INTEGER32", 0x1000)
         var.data_type = od.INTEGER32
         var.factor = 1000
@@ -204,7 +204,7 @@ class TestAlternativeRepresentations(unittest.TestCase):
         self.assertEqual(var.encode_phys(5555), 6)
 
     def test_phys_float_factor(self):
-        """Float factor still works via float division + round."""
+        """Float factor uses float division + round."""
         var = od.ODVariable("Test INTEGER16", 0x1000)
         var.data_type = od.INTEGER16
         var.factor = 0.5

--- a/test/test_od.py
+++ b/test/test_od.py
@@ -211,6 +211,13 @@ class TestAlternativeRepresentations(unittest.TestCase):
         # 10 / 0.5 = 20
         self.assertEqual(var.encode_phys(10), 20)
 
+    def test_phys_float_factor_decodes_to_float(self):
+        """decode_phys with float factor ensures a float result."""
+        var = od.ODVariable("Test INTEGER32", 0x1000)
+        var.data_type = od.INTEGER32
+        var.factor = 1.0
+        self.assertIsInstance(var.decode_phys(42), float)
+
     def test_desc(self):
         var = od.ODVariable("Test UNSIGNED8", 0x1000)
         var.data_type = od.UNSIGNED8

--- a/test/test_od.py
+++ b/test/test_od.py
@@ -182,6 +182,35 @@ class TestAlternativeRepresentations(unittest.TestCase):
         self.assertAlmostEqual(var.decode_phys(128), 12.8)
         self.assertEqual(var.encode_phys(-0.1), -1)
 
+    def test_phys_factor_1_int64_roundtrip(self):
+        """int64 values must survive encode_phys when factor is 1."""
+        var = od.ODVariable("Test UNSIGNED64", 0x1000)
+        var.data_type = od.UNSIGNED64
+        value = 0x55554444AAAABBBB
+        self.assertEqual(var.encode_phys(value), value)
+
+    def test_phys_factor_1_preserves_int(self):
+        """encode_phys with factor=1 must not convert int to float."""
+        var = od.ODVariable("Test INTEGER32", 0x1000)
+        var.data_type = od.INTEGER32
+        self.assertIsInstance(var.encode_phys(42), int)
+
+    def test_phys_factor_1000_rounds(self):
+        """Existing rounding behaviour with integer factor != 1 is preserved."""
+        var = od.ODVariable("Test INTEGER32", 0x1000)
+        var.data_type = od.INTEGER32
+        var.factor = 1000
+        # 5555 / 1000 = 5.555 → round → 6
+        self.assertEqual(var.encode_phys(5555), 6)
+
+    def test_phys_float_factor(self):
+        """Float factor still works via float division + round."""
+        var = od.ODVariable("Test INTEGER16", 0x1000)
+        var.data_type = od.INTEGER16
+        var.factor = 0.5
+        # 10 / 0.5 = 20
+        self.assertEqual(var.encode_phys(10), 20)
+
     def test_desc(self):
         var = od.ODVariable("Test UNSIGNED8", 0x1000)
         var.data_type = od.UNSIGNED8


### PR DESCRIPTION
Skip the float division in encode_phys when factor is 1 (the default). Previously, `value /= self.factor` always performed float division, causing up to 10 bits of precision loss for large int64 values (e.g. 0x55554444AAAABBBB became 0x55554444AAAABC00).

Use `!= 1` for the comparison since we are comparing values, not identity. Also clean up the redundant int(round(...)) to just round(), since round() already returns int when ndigits is omitted.

Add unit tests covering:
- int64 roundtrip with factor=1 (the original bug)
- int type preservation with factor=1
- rounding with integer factor != 1 (existing behavior preserved)
- float factor (existing behavior preserved)

Based on the discussion in #611.