### PR TITLE
Fix __contains__ and __eq__ override signatures

### DIFF
--- a/canopen/objectdictionary/__init__.py
+++ b/canopen/objectdictionary/__init__.py
@@ -160,7 +160,7 @@ class ObjectDictionary(MutableMapping):
     def __len__(self) -> int:
         return len(self.indices)
 
-    def __contains__(self, index: Union[int, str]):
+    def __contains__(self, index: object) -> bool:
         return index in self.names or index in self.indices
 
     def add_object(self, obj: Union[ODArray, ODRecord, ODVariable]) -> None:
@@ -234,10 +234,12 @@ class ODRecord(MutableMapping):
     def __iter__(self) -> Iterator[int]:
         return iter(sorted(self.subindices))
 
-    def __contains__(self, subindex: Union[int, str]) -> bool:
+    def __contains__(self, subindex: object) -> bool:
         return subindex in self.names or subindex in self.subindices
 
-    def __eq__(self, other: ODRecord) -> bool:
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, ODRecord):
+            return NotImplemented
         return self.index == other.index
 
     def add_member(self, variable: ODVariable) -> None:
@@ -298,7 +300,9 @@ class ODArray(Mapping):
     def __iter__(self) -> Iterator[int]:
         return iter(sorted(self.subindices))
 
-    def __eq__(self, other: ODArray) -> bool:
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, ODArray):
+            return NotImplemented
         return self.index == other.index
 
     def add_member(self, variable: ODVariable) -> None:
@@ -387,7 +391,9 @@ class ODVariable:
             return f"{self.parent.name}.{self.name}"
         return self.name
 
-    def __eq__(self, other: ODVariable) -> bool:
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, ODVariable):
+            return NotImplemented
         return (self.index == other.index and
                 self.subindex == other.subindex)
 

--- a/canopen/sdo/base.py
+++ b/canopen/sdo/base.py
@@ -64,7 +64,7 @@ class SdoBase(Mapping):
     def __len__(self) -> int:
         return len(self.od)
 
-    def __contains__(self, key: Union[int, str]) -> bool:
+    def __contains__(self, key: object) -> bool:
         return key in self.od
 
     def get_variable(
@@ -113,7 +113,7 @@ class SdoRecord(Mapping):
         # Skip the "highest subindex" entry, which is not part of the data
         return len(self.od) - int(0 in self.od)
 
-    def __contains__(self, subindex: Union[int, str]) -> bool:
+    def __contains__(self, subindex: object) -> bool:
         return subindex in self.od
 
 
@@ -136,7 +136,9 @@ class SdoArray(Mapping):
     def __len__(self) -> int:
         return self[0].raw
 
-    def __contains__(self, subindex: int) -> bool:
+    def __contains__(self, subindex: object) -> bool:
+        if not isinstance(subindex, int):
+            return False
         return 0 <= subindex <= len(self)
 
 

--- a/test/test_od.py
+++ b/test/test_od.py
@@ -276,5 +276,23 @@ class TestArray(unittest.TestCase):
         self.assertEqual(array[3].name, "Test Variable_3")
 
 
+class TestEquality(unittest.TestCase):
+
+    def test_record_eq_wrong_type(self):
+        record = od.ODRecord("Test Record", 0x1001)
+        self.assertNotEqual(record, "not a record")
+        self.assertNotEqual(record, 42)
+
+    def test_array_eq_wrong_type(self):
+        array = od.ODArray("Test Array", 0x1002)
+        self.assertNotEqual(array, "not an array")
+        self.assertNotEqual(array, 42)
+
+    def test_variable_eq_wrong_type(self):
+        var = od.ODVariable("Test Variable", 0x1000, 0)
+        self.assertNotEqual(var, "not a variable")
+        self.assertNotEqual(var, 42)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_sdo.py
+++ b/test/test_sdo.py
@@ -48,6 +48,12 @@ class TestSDOVariables(unittest.TestCase):
         for var in array.values():
             self.assertIsInstance(var, canopen.sdo.SdoVariable)
 
+    def test_array_contains_non_int(self):
+        """SdoArray.__contains__ should handle non-int types gracefully."""
+        array = self.sdo_node[0x1003]
+        self.assertNotIn("not an int", array)
+        self.assertNotIn(None, array)
+
 
 class TestSDO(unittest.TestCase):
     """


### PR DESCRIPTION
Fix `__contains__` and `__eq__` override signatures to satisfy the Liskov substitution principle.

## Problem

mypy reports `[override]` errors because `__contains__` and `__eq__` methods use specific types (`Union[int, str]`, `ODRecord`, etc.) instead of `object` as required by the `Mapping`, `Container`, and `object` supertypes.

## Changes

### `canopen/objectdictionary/__init__.py`
- `ObjectDictionary.__contains__`: accept `object` instead of `Union[int, str]`
- `ODRecord.__contains__`: accept `object` instead of `Union[int, str]`
- `ODRecord.__eq__`: accept `object`, return `NotImplemented` for non-`ODRecord`
- `ODArray.__eq__`: accept `object`, return `NotImplemented` for non-`ODArray`
- `ODVariable.__eq__`: accept `object`, return `NotImplemented` for non-`ODVariable`

### `canopen/sdo/base.py`
- `SdoBase.__contains__`: accept `object` instead of `Union[int, str]`
- `SdoRecord.__contains__`: accept `object` instead of `Union[int, str]`
- `SdoArray.__contains__`: accept `object` instead of `int`, add `isinstance` guard

## Impact
Eliminates all 18 `[override]` mypy errors (95 → 77 remaining).