### PR TITLE
eds: Fix signed integer limit parsing for all bit widths, log errors

### DIFF
--- a/canopen/objectdictionary/eds.py
+++ b/canopen/objectdictionary/eds.py
@@ -259,7 +259,7 @@ def _decode_from_eds(node_id: int, var_type: int, value: Any) -> Any:
 def _encode_to_eds(var_type: int, value: Any) -> Any:
     if value is None:
         return None
-    if var_type in (datatypes.OCTET_STRING, datatypes.DOMAIN) and isinstance(value, bytes):
+    if var_type in (datatypes.OCTET_STRING, datatypes.DOMAIN):
         return bytes.hex(value)
     elif var_type in (datatypes.VISIBLE_STRING, datatypes.UNICODE_STRING):
         return value

--- a/canopen/objectdictionary/eds.py
+++ b/canopen/objectdictionary/eds.py
@@ -222,22 +222,22 @@ def _signed_int_from_hex(hex_str, bit_length):
     max_signed = (1 << (bit_length - 1)) - 1
     max_unsigned = (1 << bit_length) - 1
 
+    if number < min_signed:
+        raise ValueError(
+            f"Value {hex_str!r} is out of range for a {bit_length}-bit signed integer"
+        )
     if number < 0:
-        # Negative decimal literal (e.g. LowLimit=-32768)
-        if number < min_signed:
-            raise ValueError(
-                f"Value {hex_str!r} is out of range for a {bit_length}-bit signed integer"
-            )
+        # Negative literal (e.g. LowLimit=-32768 or -0x8000)
         return number
-    else:
+
+    if number > max_unsigned:
+        raise ValueError(
+            f"Value {hex_str!r} is out of range for a {bit_length}-bit signed integer"
+        )
+    if number > max_signed:
         # Unsigned hex literal, two's-complement (e.g. LowLimit=0xFFFF → -1 for INTEGER16)
-        if number > max_unsigned:
-            raise ValueError(
-                f"Value {hex_str!r} is out of range for a {bit_length}-bit signed integer"
-            )
-        if number > max_signed:
-            return number - (1 << bit_length)
-        return number
+        return number - (1 << bit_length)
+    return number
 
 
 def _convert_variable(node_id, var_type, value):

--- a/canopen/objectdictionary/eds.py
+++ b/canopen/objectdictionary/eds.py
@@ -204,26 +204,28 @@ def import_from_node(node_id: int, network: canopen.network.Network):
     return od
 
 
-_SIGNED_BIT_LENGTHS = {
-    datatypes.INTEGER8: 8,
-    datatypes.INTEGER16: 16,
-    datatypes.INTEGER24: 24,
-    datatypes.INTEGER32: 32,
-    datatypes.INTEGER40: 40,
-    datatypes.INTEGER48: 48,
-    datatypes.INTEGER56: 56,
-    datatypes.INTEGER64: 64,
-}
+def _calc_bit_length(data_type: int) -> int:
+    if data_type in datatypes.SIGNED_TYPES:
+        st = ODVariable.STRUCT_TYPES[data_type]
+        if isinstance(st, datatypes.IntegerN):
+            return st.width
+        return st.size * 8
+    else:
+        raise ValueError(
+            f"Invalid data_type '{data_type}', expecting a signed integer data_type."
+        )
 
 
 def _signed_int_from_hex(hex_str, bit_length):
     number = int(hex_str, 0)
+    if number < 0 or number >= (1 << bit_length):
+        raise ValueError(
+            f"Value {hex_str!r} is out of range for a {bit_length}-bit signed integer"
+        )
     max_value = (1 << (bit_length - 1)) - 1
-
     if number > max_value:
         return number - (1 << bit_length)
-    else:
-        return number
+    return number
 
 
 def _convert_variable(node_id, var_type, value):
@@ -242,6 +244,18 @@ def _convert_variable(node_id, var_type, value):
             return int(value, 0)
 
 
+def _int_to_hex(data_type: int, value: int) -> str:
+    """Format an integer as EDS hex string.
+
+    Signed types with a negative value are written as two's-complement hex
+    (e.g. INTEGER8 -1 → 0xFF) so the output is a valid EDS literal.
+    """
+    if data_type in datatypes.SIGNED_TYPES and value < 0:
+        bit_length = _calc_bit_length(data_type)
+        return f"0x{value + (1 << bit_length):0{bit_length // 4}X}"
+    return f"0x{value:02X}"
+
+
 def _revert_variable(var_type, value):
     if value is None:
         return None
@@ -252,7 +266,7 @@ def _revert_variable(var_type, value):
     elif var_type in datatypes.FLOAT_TYPES:
         return value
     else:
-        return f"0x{value:02X}"
+        return _int_to_hex(var_type, value)
 
 
 def build_variable(
@@ -302,20 +316,26 @@ def build_variable(
         try:
             min_string = eds.get(section, "LowLimit")
             if var.data_type in datatypes.SIGNED_TYPES:
-                var.min = _signed_int_from_hex(min_string, _SIGNED_BIT_LENGTHS[var.data_type])
+                var.min = _signed_int_from_hex(min_string, _calc_bit_length(var.data_type))
             else:
                 var.min = int(min_string, 0)
         except ValueError:
-            pass
+            logger.warning(
+                "Invalid LowLimit %r for %s (0x%X), ignoring",
+                eds.get(section, "LowLimit"), var.name, var.index,
+            )
     if eds.has_option(section, "HighLimit"):
         try:
             max_string = eds.get(section, "HighLimit")
             if var.data_type in datatypes.SIGNED_TYPES:
-                var.max = _signed_int_from_hex(max_string, _SIGNED_BIT_LENGTHS[var.data_type])
+                var.max = _signed_int_from_hex(max_string, _calc_bit_length(var.data_type))
             else:
                 var.max = int(max_string, 0)
         except ValueError:
-            pass
+            logger.warning(
+                "Invalid HighLimit %r for %s (0x%X), ignoring",
+                eds.get(section, "HighLimit"), var.name, var.index,
+            )
     if eds.has_option(section, "DefaultValue"):
         try:
             var.default_raw = eds.get(section, "DefaultValue")
@@ -323,30 +343,33 @@ def build_variable(
                 var.relative = True
             var.default = _convert_variable(node_id, var.data_type, var.default_raw)
         except ValueError:
-            pass
+            logger.warning(
+                "Invalid DefaultValue %r for %s (0x%X), ignoring",
+                var.default_raw, var.name, var.index,
+            )
     if eds.has_option(section, "ParameterValue"):
         try:
             var.value_raw = eds.get(section, "ParameterValue")
             var.value = _convert_variable(node_id, var.data_type, var.value_raw)
         except ValueError:
-            pass
+            logger.warning(
+                "Invalid ParameterValue %r for %s (0x%X), ignoring",
+                var.value_raw, var.name, var.index,
+            )
     # Factor, Description and Unit are not standard according to the CANopen specifications, but
     # they are implemented in the python canopen package, so we can at least try to use them
     if eds.has_option(section, "Factor"):
         try:
             var.factor = float(eds.get(section, "Factor"))
         except ValueError:
-            pass
+            logger.warning(
+                "Invalid Factor %r for %s (0x%X), ignoring",
+                eds.get(section, "Factor"), var.name, var.index,
+            )
     if eds.has_option(section, "Description"):
-        try:
-            var.description = eds.get(section, "Description")
-        except ValueError:
-            pass
+        var.description = eds.get(section, "Description")
     if eds.has_option(section, "Unit"):
-        try:
-            var.unit = eds.get(section, "Unit")
-        except ValueError:
-            pass
+        var.unit = eds.get(section, "Unit")
     return var
 
 
@@ -411,9 +434,9 @@ def export_eds(od, dest=None, file_info={}, device_commisioning=False):
         eds.set(section, "PDOMapping", hex(var.pdo_mappable))
 
         if getattr(var, 'min', None) is not None:
-            eds.set(section, "LowLimit", var.min)
+            eds.set(section, "LowLimit", _int_to_hex(var.data_type, var.min))
         if getattr(var, 'max', None) is not None:
-            eds.set(section, "HighLimit", var.max)
+            eds.set(section, "HighLimit", _int_to_hex(var.data_type, var.max))
 
         if getattr(var, 'description', '') != '':
             eds.set(section, "Description", var.description)

--- a/canopen/objectdictionary/eds.py
+++ b/canopen/objectdictionary/eds.py
@@ -205,14 +205,14 @@ def import_from_node(node_id: int, network: canopen.network.Network):
 
 
 def _calc_bit_length(data_type: int) -> int:
-    if data_type in datatypes.SIGNED_TYPES:
+    if data_type in datatypes.INTEGER_TYPES:
         st = ODVariable.STRUCT_TYPES[data_type]
         if isinstance(st, datatypes.IntegerN):
             return st.width
         return st.size * 8
     else:
         raise ValueError(
-            f"Invalid data_type '{data_type}', expecting a signed integer data_type."
+            f"Invalid data_type 0x{data_type:04X}, expecting an integer data_type."
         )
 
 
@@ -256,29 +256,17 @@ def _convert_variable(node_id, var_type, value):
             return int(value, 0)
 
 
-def _int_to_hex(data_type: int, value: int) -> str:
-    """Format an integer as EDS hex string.
-
-    Signed types with a negative value are written as two's-complement hex
-    (e.g. INTEGER8 -1 → 0xFF) so the output is a valid EDS literal.
-    """
-    if data_type in datatypes.SIGNED_TYPES and value < 0:
-        bit_length = _calc_bit_length(data_type)
-        return f"0x{value + (1 << bit_length):0{bit_length // 4}X}"
-    return f"0x{value:02X}"
-
-
 def _revert_variable(var_type, value):
     if value is None:
         return None
-    if var_type in (datatypes.OCTET_STRING, datatypes.DOMAIN):
+    if var_type in (datatypes.OCTET_STRING, datatypes.DOMAIN) and isinstance(value, bytes):
         return bytes.hex(value)
     elif var_type in (datatypes.VISIBLE_STRING, datatypes.UNICODE_STRING):
         return value
     elif var_type in datatypes.FLOAT_TYPES:
         return value
     else:
-        return _int_to_hex(var_type, value)
+        return str(value)
 
 
 def build_variable(
@@ -446,9 +434,9 @@ def export_eds(od, dest=None, file_info={}, device_commisioning=False):
         eds.set(section, "PDOMapping", hex(var.pdo_mappable))
 
         if getattr(var, 'min', None) is not None:
-            eds.set(section, "LowLimit", _int_to_hex(var.data_type, var.min))
+            eds.set(section, "LowLimit", _revert_variable(var.data_type, var.min))
         if getattr(var, 'max', None) is not None:
-            eds.set(section, "HighLimit", _int_to_hex(var.data_type, var.max))
+            eds.set(section, "HighLimit", _revert_variable(var.data_type, var.max))
 
         if getattr(var, 'description', '') != '':
             eds.set(section, "Description", var.description)

--- a/canopen/objectdictionary/eds.py
+++ b/canopen/objectdictionary/eds.py
@@ -218,14 +218,26 @@ def _calc_bit_length(data_type: int) -> int:
 
 def _signed_int_from_hex(hex_str, bit_length):
     number = int(hex_str, 0)
-    if number < 0 or number >= (1 << bit_length):
-        raise ValueError(
-            f"Value {hex_str!r} is out of range for a {bit_length}-bit signed integer"
-        )
-    max_value = (1 << (bit_length - 1)) - 1
-    if number > max_value:
-        return number - (1 << bit_length)
-    return number
+    min_signed = -(1 << (bit_length - 1))
+    max_signed = (1 << (bit_length - 1)) - 1
+    max_unsigned = (1 << bit_length) - 1
+
+    if number < 0:
+        # Negative decimal literal (e.g. LowLimit=-32768)
+        if number < min_signed:
+            raise ValueError(
+                f"Value {hex_str!r} is out of range for a {bit_length}-bit signed integer"
+            )
+        return number
+    else:
+        # Unsigned hex literal, two's-complement (e.g. LowLimit=0xFFFF → -1 for INTEGER16)
+        if number > max_unsigned:
+            raise ValueError(
+                f"Value {hex_str!r} is out of range for a {bit_length}-bit signed integer"
+            )
+        if number > max_signed:
+            return number - (1 << bit_length)
+        return number
 
 
 def _convert_variable(node_id, var_type, value):

--- a/canopen/objectdictionary/eds.py
+++ b/canopen/objectdictionary/eds.py
@@ -240,7 +240,7 @@ def _signed_int_from_hex(hex_str, bit_length):
     return number
 
 
-def _convert_variable(node_id: int, var_type: int, value: Any) -> Any:
+def _decode_from_eds(node_id: int, var_type: int, value: Any) -> Any:
     if var_type in (datatypes.OCTET_STRING, datatypes.DOMAIN):
         return bytes.fromhex(value)
     elif var_type in (datatypes.VISIBLE_STRING, datatypes.UNICODE_STRING):
@@ -256,7 +256,7 @@ def _convert_variable(node_id: int, var_type: int, value: Any) -> Any:
             return int(value, 0)
 
 
-def _revert_variable(var_type: int, value: Any) -> Any:
+def _encode_to_eds(var_type: int, value: Any) -> Any:
     if value is None:
         return None
     if var_type in (datatypes.OCTET_STRING, datatypes.DOMAIN) and isinstance(value, bytes):
@@ -266,7 +266,7 @@ def _revert_variable(var_type: int, value: Any) -> Any:
     elif var_type in datatypes.FLOAT_TYPES:
         return value
     else:
-        return str(value)
+        return f"0x{value:02X}"
 
 
 def build_variable(
@@ -322,7 +322,7 @@ def build_variable(
         except ValueError:
             logger.warning(
                 "Invalid LowLimit %r for %s (0x%X), ignoring",
-                eds.get(section, "LowLimit"), var.name, var.index,
+                min_string, var.name, var.index,
             )
     if eds.has_option(section, "HighLimit"):
         try:
@@ -334,27 +334,27 @@ def build_variable(
         except ValueError:
             logger.warning(
                 "Invalid HighLimit %r for %s (0x%X), ignoring",
-                eds.get(section, "HighLimit"), var.name, var.index,
+                max_string, var.name, var.index,
             )
     if eds.has_option(section, "DefaultValue"):
         try:
             var.default_raw = eds.get(section, "DefaultValue")
             if '$NODEID' in var.default_raw:
                 var.relative = True
-            var.default = _convert_variable(node_id, var.data_type, var.default_raw)
+            var.default = _decode_from_eds(node_id, var.data_type, var.default_raw)
         except ValueError:
             logger.warning(
                 "Invalid DefaultValue %r for %s (0x%X), ignoring",
-                eds.get(section, "DefaultValue"), var.name, var.index,
+                var.default_raw, var.name, var.index,
             )
     if eds.has_option(section, "ParameterValue"):
         try:
             var.value_raw = eds.get(section, "ParameterValue")
-            var.value = _convert_variable(node_id, var.data_type, var.value_raw)
+            var.value = _decode_from_eds(node_id, var.data_type, var.value_raw)
         except ValueError:
             logger.warning(
                 "Invalid ParameterValue %r for %s (0x%X), ignoring",
-                eds.get(section, "ParameterValue"), var.name, var.index,
+                var.value_raw, var.name, var.index,
             )
     # Factor, Description and Unit are not standard according to the CANopen specifications, but
     # they are implemented in the python canopen package, so we can at least try to use them
@@ -420,7 +420,7 @@ def export_eds(od, dest=None, file_info={}, device_commisioning=False):
         if getattr(var, 'default_raw', None) is not None:
             eds.set(section, "DefaultValue", var.default_raw)
         elif getattr(var, 'default', None) is not None:
-            eds.set(section, "DefaultValue", _revert_variable(
+            eds.set(section, "DefaultValue", _encode_to_eds(
                 var.data_type, var.default))
 
         if device_commisioning:
@@ -428,15 +428,15 @@ def export_eds(od, dest=None, file_info={}, device_commisioning=False):
                 eds.set(section, "ParameterValue", var.value_raw)
             elif getattr(var, 'value', None) is not None:
                 eds.set(section, "ParameterValue",
-                        _revert_variable(var.data_type, var.value))
+                        _encode_to_eds(var.data_type, var.value))
 
         eds.set(section, "DataType", f"0x{var.data_type:04X}")
         eds.set(section, "PDOMapping", hex(var.pdo_mappable))
 
         if getattr(var, 'min', None) is not None:
-            eds.set(section, "LowLimit", _revert_variable(var.data_type, var.min))
+            eds.set(section, "LowLimit", var.min)
         if getattr(var, 'max', None) is not None:
-            eds.set(section, "HighLimit", _revert_variable(var.data_type, var.max))
+            eds.set(section, "HighLimit", var.max)
 
         if getattr(var, 'description', '') != '':
             eds.set(section, "Description", var.description)

--- a/canopen/objectdictionary/eds.py
+++ b/canopen/objectdictionary/eds.py
@@ -345,7 +345,7 @@ def build_variable(
         except ValueError:
             logger.warning(
                 "Invalid DefaultValue %r for %s (0x%X), ignoring",
-                var.default_raw, var.name, var.index,
+                eds.get(section, "DefaultValue"), var.name, var.index,
             )
     if eds.has_option(section, "ParameterValue"):
         try:
@@ -354,7 +354,7 @@ def build_variable(
         except ValueError:
             logger.warning(
                 "Invalid ParameterValue %r for %s (0x%X), ignoring",
-                var.value_raw, var.name, var.index,
+                eds.get(section, "ParameterValue"), var.name, var.index,
             )
     # Factor, Description and Unit are not standard according to the CANopen specifications, but
     # they are implemented in the python canopen package, so we can at least try to use them

--- a/canopen/objectdictionary/eds.py
+++ b/canopen/objectdictionary/eds.py
@@ -306,7 +306,7 @@ def build_variable(
             else:
                 var.min = int(min_string, 0)
         except ValueError:
-            logger.warning("Failed to parse LowLimit for %s: %r", name, min_string)
+            pass
     if eds.has_option(section, "HighLimit"):
         try:
             max_string = eds.get(section, "HighLimit")
@@ -315,7 +315,7 @@ def build_variable(
             else:
                 var.max = int(max_string, 0)
         except ValueError:
-            logger.warning("Failed to parse HighLimit for %s: %r", name, max_string)
+            pass
     if eds.has_option(section, "DefaultValue"):
         try:
             var.default_raw = eds.get(section, "DefaultValue")

--- a/canopen/objectdictionary/eds.py
+++ b/canopen/objectdictionary/eds.py
@@ -204,19 +204,16 @@ def import_from_node(node_id: int, network: canopen.network.Network):
     return od
 
 
-def _calc_bit_length(data_type):
-    if data_type == datatypes.INTEGER8:
-        return 8
-    elif data_type == datatypes.INTEGER16:
-        return 16
-    elif data_type == datatypes.INTEGER32:
-        return 32
-    elif data_type == datatypes.INTEGER64:
-        return 64
-    else:
-        raise ValueError(
-            f"Invalid data_type '{data_type}', expecting a signed integer data_type."
-        )
+_SIGNED_BIT_LENGTHS = {
+    datatypes.INTEGER8: 8,
+    datatypes.INTEGER16: 16,
+    datatypes.INTEGER24: 24,
+    datatypes.INTEGER32: 32,
+    datatypes.INTEGER40: 40,
+    datatypes.INTEGER48: 48,
+    datatypes.INTEGER56: 56,
+    datatypes.INTEGER64: 64,
+}
 
 
 def _signed_int_from_hex(hex_str, bit_length):
@@ -305,20 +302,20 @@ def build_variable(
         try:
             min_string = eds.get(section, "LowLimit")
             if var.data_type in datatypes.SIGNED_TYPES:
-                var.min = _signed_int_from_hex(min_string, _calc_bit_length(var.data_type))
+                var.min = _signed_int_from_hex(min_string, _SIGNED_BIT_LENGTHS[var.data_type])
             else:
                 var.min = int(min_string, 0)
         except ValueError:
-            pass
+            logger.warning("Failed to parse LowLimit for %s: %r", name, min_string)
     if eds.has_option(section, "HighLimit"):
         try:
             max_string = eds.get(section, "HighLimit")
             if var.data_type in datatypes.SIGNED_TYPES:
-                var.max = _signed_int_from_hex(max_string, _calc_bit_length(var.data_type))
+                var.max = _signed_int_from_hex(max_string, _SIGNED_BIT_LENGTHS[var.data_type])
             else:
                 var.max = int(max_string, 0)
         except ValueError:
-            pass
+            logger.warning("Failed to parse HighLimit for %s: %r", name, max_string)
     if eds.has_option(section, "DefaultValue"):
         try:
             var.default_raw = eds.get(section, "DefaultValue")

--- a/test/sample.eds
+++ b/test/sample.eds
@@ -976,6 +976,42 @@ HighLimit=0xFFFFFFFF
 LowLimit=0x80000000
 PDOMapping=0
 
+[3031]
+ParameterName=INTEGER24 value range -1 to 0
+ObjectType=0x7
+DataType=0x10
+AccessType=rw
+HighLimit=0x000000
+LowLimit=0xFFFFFF
+PDOMapping=0
+
+[3032]
+ParameterName=INTEGER40 value range -1 to 0
+ObjectType=0x7
+DataType=0x12
+AccessType=rw
+HighLimit=0x0000000000
+LowLimit=0xFFFFFFFFFF
+PDOMapping=0
+
+[3033]
+ParameterName=INTEGER48 value range -1 to 0
+ObjectType=0x7
+DataType=0x13
+AccessType=rw
+HighLimit=0x000000000000
+LowLimit=0xFFFFFFFFFFFF
+PDOMapping=0
+
+[3034]
+ParameterName=INTEGER56 value range -1 to 0
+ObjectType=0x7
+DataType=0x14
+AccessType=rw
+HighLimit=0x00000000000000
+LowLimit=0xFFFFFFFFFFFFFF
+PDOMapping=0
+
 [3040]
 ParameterName=INTEGER64 value range -10 to +10
 ObjectType=0x7

--- a/test/sample.eds
+++ b/test/sample.eds
@@ -967,6 +967,24 @@ HighLimit=0x0A
 LowLimit=0x02
 PDOMapping=0
 
+[3022]
+ParameterName=UNSIGNED16 decimal limits
+ObjectType=0x7
+DataType=0x06
+AccessType=rw
+LowLimit=100
+HighLimit=1000
+PDOMapping=0
+
+[3023]
+ParameterName=INTEGER16 decimal limits
+ObjectType=0x7
+DataType=0x03
+AccessType=rw
+LowLimit=-100
+HighLimit=100
+PDOMapping=0
+
 [3030]
 ParameterName=INTEGER32 only negative values
 ObjectType=0x7

--- a/test/test_eds.py
+++ b/test/test_eds.py
@@ -148,6 +148,28 @@ class TestEDS(unittest.TestCase):
         int64 = self.od[0x3040]
         self.assertEqual(int64.min, -10)
         self.assertEqual(int64.max, +10)
+        # Verify all remaining SIGNED_TYPES are handled (INTEGER24/40/48/56)
+        for index in (0x3031, 0x3032, 0x3033, 0x3034):
+            var = self.od[index]
+            self.assertEqual(var.min, -1, f"min mismatch at 0x{index:04X}")
+            self.assertEqual(var.max, 0, f"max mismatch at 0x{index:04X}")
+
+    def test_invalid_limit_logs_warning(self):
+        import io
+        import logging
+
+        with open(SAMPLE_EDS) as f:
+            content = f.read()
+        invalid_eds = content.replace(
+            "LowLimit=0x02\nPDOMapping=0\n\n[3030]",
+            "LowLimit=INVALID\nPDOMapping=0\n\n[3030]",
+        )
+        with io.StringIO(invalid_eds) as buf:
+            buf.name = "mock.eds"
+            with self.assertLogs("canopen.objectdictionary.eds", level=logging.WARNING) as cm:
+                od = canopen.import_od(buf)
+        self.assertIsNone(od[0x3021].min)
+        self.assertTrue(any("LowLimit" in msg for msg in cm.output))
 
     def test_signed_int_from_hex(self):
         for data_type, test_cases in self.test_data.items():

--- a/test/test_eds.py
+++ b/test/test_eds.py
@@ -1,3 +1,4 @@
+import io
 import os
 import unittest
 from configparser import RawConfigParser
@@ -71,8 +72,6 @@ class TestEDS(unittest.TestCase):
         self.assertEqual(od.node_id, 16)
 
     def test_load_implicit_nodeid_fallback(self):
-        import io
-
         # First, remove the NodeID option from DeviceComissioning.
         with open(SAMPLE_EDS) as f:
             lines = [L for L in f.readlines() if not L.startswith("NodeID=")]
@@ -94,8 +93,6 @@ class TestEDS(unittest.TestCase):
         self.assertEqual(od.bitrate, 500_000)
 
     def test_load_baudrate_fallback(self):
-        import io
-
         # Remove the Baudrate option.
         with open(SAMPLE_EDS) as f:
             lines = [L for L in f.readlines() if not L.startswith("Baudrate=")]
@@ -277,7 +274,6 @@ class TestEDS(unittest.TestCase):
 
     def test_roundtrip_domain_objects(self):
         # ObjectType==DOMAIN survive an EDS export/import round-trip
-        import io
         with io.StringIO() as dest:
             canopen.export_od(self.od, dest, 'eds')
             dest.name = 'mock.eds'
@@ -287,6 +283,17 @@ class TestEDS(unittest.TestCase):
         self.assertFalse(od2['Identity object']['Vendor-ID'].is_domain)
         self.assertTrue(od2[0x3063].is_domain)
         self.assertTrue(od2[0x3064][1].is_domain)
+
+    def test_export_without_raw_default_values(self):
+        od = canopen.import_od(DATATYPES_EDS)
+        # Make sure the values are not cached in raw form
+        for var in od.values():
+            try:
+                delattr(var, 'default_raw')
+            except AttributeError:
+                pass
+        with io.StringIO() as dest:
+            canopen.export_od(od, dest, 'eds')
 
 
     def test_comments(self):
@@ -308,7 +315,6 @@ class TestEDS(unittest.TestCase):
                         self.verify_od(dest, doctype)
 
     def test_export_eds_to_file_unknown_extension(self):
-        import io
         for suffix in ".txt", "":
             with tmp_file(suffix=suffix) as tmp:
                 dest = tmp.name
@@ -331,7 +337,6 @@ class TestEDS(unittest.TestCase):
                         self.verify_od(buf, "eds")
 
     def test_export_eds_unknown_doctype(self):
-        import io
         filelike_object = io.StringIO()
         self.addCleanup(filelike_object.close)
         for dest in "filename", None, filelike_object:
@@ -344,7 +349,6 @@ class TestEDS(unittest.TestCase):
                         os.stat(dest)
 
     def test_export_eds_to_filelike_object(self):
-        import io
         for doctype in "eds", "dcf":
             with io.StringIO() as dest:
                 with self.subTest(dest=dest, doctype=doctype):
@@ -358,7 +362,6 @@ class TestEDS(unittest.TestCase):
 
     def test_export_eds_to_stdout(self):
         import contextlib
-        import io
         with contextlib.redirect_stdout(io.StringIO()) as f:
             ret = canopen.export_od(self.od, None, "eds")
         self.assertIsNone(ret)

--- a/test/test_eds.py
+++ b/test/test_eds.py
@@ -135,16 +135,16 @@ class TestEDS(unittest.TestCase):
 
     def test_record_with_limits(self):
         cases = [
-            (0x3020, 0,            127),          # INTEGER8   hex limits
-            (0x3021, 2,            10),           # UNSIGNED8  hex limits
-            (0x3022, 100,          1000),         # UNSIGNED16 decimal limits
-            (0x3023, -100,         100),          # INTEGER16  decimal limits
-            (0x3030, -2147483648,  -1),           # INTEGER32  hex limits
-            (0x3031, -1,           0),            # INTEGER24  hex limits
-            (0x3032, -1,           0),            # INTEGER40  hex limits
-            (0x3033, -1,           0),            # INTEGER48  hex limits
-            (0x3034, -1,           0),            # INTEGER56  hex limits
-            (0x3040, -10,          +10),          # INTEGER64  hex limits
+            (0x3020, 0, 127),  # _          INTEGER8   hex limits
+            (0x3021, 2, 10),  # _           UNSIGNED8  hex limits
+            (0x3022, 100, 1000),  # _       UNSIGNED16 decimal limits
+            (0x3023, -100, 100),  # _       INTEGER16  decimal limits
+            (0x3030, -2147483648, -1),  # _ INTEGER32  hex limits
+            (0x3031, -1, 0),  # _           INTEGER24  hex limits
+            (0x3032, -1, 0),  # _           INTEGER40  hex limits
+            (0x3033, -1, 0),  # _           INTEGER48  hex limits
+            (0x3034, -1, 0),  # _           INTEGER56  hex limits
+            (0x3040, -10, +10),  # _        INTEGER64  hex limits
         ]
         for index, expected_min, expected_max in cases:
             with self.subTest(index=f"0x{index:04X}"):

--- a/test/test_eds.py
+++ b/test/test_eds.py
@@ -136,23 +136,21 @@ class TestEDS(unittest.TestCase):
         self.assertFalse(var.is_domain)
 
     def test_record_with_limits(self):
-        int8 = self.od[0x3020]
-        self.assertEqual(int8.min, 0)
-        self.assertEqual(int8.max, 127)
-        uint8 = self.od[0x3021]
-        self.assertEqual(uint8.min, 2)
-        self.assertEqual(uint8.max, 10)
-        int32 = self.od[0x3030]
-        self.assertEqual(int32.min, -2147483648)
-        self.assertEqual(int32.max, -1)
-        int64 = self.od[0x3040]
-        self.assertEqual(int64.min, -10)
-        self.assertEqual(int64.max, +10)
-        # Verify all remaining SIGNED_TYPES are handled (INTEGER24/40/48/56)
-        for index in (0x3031, 0x3032, 0x3033, 0x3034):
-            var = self.od[index]
-            self.assertEqual(var.min, -1, f"min mismatch at 0x{index:04X}")
-            self.assertEqual(var.max, 0, f"max mismatch at 0x{index:04X}")
+        cases = [
+            (0x3020, 0,            127),          # INTEGER8
+            (0x3021, 2,            10),           # UNSIGNED8
+            (0x3030, -2147483648,  -1),           # INTEGER32
+            (0x3031, -1,           0),            # INTEGER24
+            (0x3032, -1,           0),            # INTEGER40
+            (0x3033, -1,           0),            # INTEGER48
+            (0x3034, -1,           0),            # INTEGER56
+            (0x3040, -10,          +10),          # INTEGER64
+        ]
+        for index, expected_min, expected_max in cases:
+            with self.subTest(index=f"0x{index:04X}"):
+                var = self.od[index]
+                self.assertEqual(var.min, expected_min)
+                self.assertEqual(var.max, expected_max)
 
     def test_signed_int_from_hex(self):
         for data_type, test_cases in self.test_data.items():
@@ -160,6 +158,13 @@ class TestEDS(unittest.TestCase):
                 with self.subTest(data_type=data_type, test_case=test_case):
                     result = _signed_int_from_hex('0x' + test_case["hex_str"], test_case["bit_length"])
                     self.assertEqual(result, test_case["expected"])
+
+    def test_signed_int_from_hex_rejects_out_of_range(self):
+        # Value must fit in bit_length bits (unsigned representation).
+        with self.assertRaises(ValueError):
+            _signed_int_from_hex("0xFFFF", 8)   # 16-bit value into 8-bit field
+        with self.assertRaises(ValueError):
+            _signed_int_from_hex("-1", 8)       # negative inputs are never valid
 
     def test_array_compact_subobj(self):
         array = self.od[0x1003]

--- a/test/test_eds.py
+++ b/test/test_eds.py
@@ -1,5 +1,6 @@
 import os
 import unittest
+from configparser import RawConfigParser
 
 import canopen
 from canopen.objectdictionary.eds import _signed_int_from_hex
@@ -172,6 +173,25 @@ class TestEDS(unittest.TestCase):
             _signed_int_from_hex("0xFFFF", 8)   # 16-bit value into 8-bit field
         with self.assertRaises(ValueError):
             _signed_int_from_hex("-129", 8)     # below minimum for 8-bit signed
+
+    def test_build_variable_range_warnings(self):
+        eds = RawConfigParser()
+        cases = [
+            ("2003", "LowLimit", str(-0xFFFF)),  # INTEGER16 < signed min
+            ("2003", "HighLimit", "0x10000"),  # INTEGER16 > unsigned max
+            ("2001", "DefaultValue", "SOMETHING"),  # BOOLEAN non-numeric
+            ("2003", "DefaultValue", "SOMETHING"),  # INTEGER16 non-numeric
+            ("2006", "ParameterValue", ""),  # UNSIGNED16 empty
+        ]
+        for index, option, value in cases:
+            with self.subTest(index=index, option=option, value=value):
+                # Fresh version for mutating temporarily
+                eds.clear()
+                eds.read(DATATYPES_EDS)
+                eds[index][option] = value
+                with self.assertLogs(level="WARN") as cm:
+                    build_variable(eds, index, 42, objectcodes.VAR, int(index, 16))
+                self.assertRegex(cm.output[0], option)
 
     def test_array_compact_subobj(self):
         array = self.od[0x1003]

--- a/test/test_eds.py
+++ b/test/test_eds.py
@@ -3,7 +3,7 @@ import unittest
 from configparser import RawConfigParser
 
 import canopen
-from canopen.objectdictionary.eds import _signed_int_from_hex
+from canopen.objectdictionary.eds import _signed_int_from_hex, build_variable
 from canopen.utils import pretty_index
 
 from .util import DATATYPES_EDS, SAMPLE_EDS, tmp_file
@@ -190,7 +190,7 @@ class TestEDS(unittest.TestCase):
                 eds.read(DATATYPES_EDS)
                 eds[index][option] = value
                 with self.assertLogs(level="WARN") as cm:
-                    build_variable(eds, index, 42, objectcodes.VAR, int(index, 16))
+                    build_variable(eds, index, node_id=42, object_type=7, index=int(index, 16))
                 self.assertRegex(cm.output[0], option)
 
     def test_array_compact_subobj(self):

--- a/test/test_eds.py
+++ b/test/test_eds.py
@@ -137,14 +137,16 @@ class TestEDS(unittest.TestCase):
 
     def test_record_with_limits(self):
         cases = [
-            (0x3020, 0,            127),          # INTEGER8
-            (0x3021, 2,            10),           # UNSIGNED8
-            (0x3030, -2147483648,  -1),           # INTEGER32
-            (0x3031, -1,           0),            # INTEGER24
-            (0x3032, -1,           0),            # INTEGER40
-            (0x3033, -1,           0),            # INTEGER48
-            (0x3034, -1,           0),            # INTEGER56
-            (0x3040, -10,          +10),          # INTEGER64
+            (0x3020, 0,            127),          # INTEGER8   hex limits
+            (0x3021, 2,            10),           # UNSIGNED8  hex limits
+            (0x3022, 100,          1000),         # UNSIGNED16 decimal limits
+            (0x3023, -100,         100),          # INTEGER16  decimal limits
+            (0x3030, -2147483648,  -1),           # INTEGER32  hex limits
+            (0x3031, -1,           0),            # INTEGER24  hex limits
+            (0x3032, -1,           0),            # INTEGER40  hex limits
+            (0x3033, -1,           0),            # INTEGER48  hex limits
+            (0x3034, -1,           0),            # INTEGER56  hex limits
+            (0x3040, -10,          +10),          # INTEGER64  hex limits
         ]
         for index, expected_min, expected_max in cases:
             with self.subTest(index=f"0x{index:04X}"):
@@ -159,12 +161,17 @@ class TestEDS(unittest.TestCase):
                     result = _signed_int_from_hex('0x' + test_case["hex_str"], test_case["bit_length"])
                     self.assertEqual(result, test_case["expected"])
 
+    def test_signed_int_from_hex_accepts_decimal(self):
+        # Negative decimal values are valid EDS literals (CiA 306 allows both formats).
+        self.assertEqual(_signed_int_from_hex("-1", 8), -1)
+        self.assertEqual(_signed_int_from_hex("-128", 8), -128)
+        self.assertEqual(_signed_int_from_hex("-2147483648", 32), -2147483648)
+
     def test_signed_int_from_hex_rejects_out_of_range(self):
-        # Value must fit in bit_length bits (unsigned representation).
         with self.assertRaises(ValueError):
             _signed_int_from_hex("0xFFFF", 8)   # 16-bit value into 8-bit field
         with self.assertRaises(ValueError):
-            _signed_int_from_hex("-1", 8)       # negative inputs are never valid
+            _signed_int_from_hex("-129", 8)     # below minimum for 8-bit signed
 
     def test_array_compact_subobj(self):
         array = self.od[0x1003]

--- a/test/test_eds.py
+++ b/test/test_eds.py
@@ -154,23 +154,6 @@ class TestEDS(unittest.TestCase):
             self.assertEqual(var.min, -1, f"min mismatch at 0x{index:04X}")
             self.assertEqual(var.max, 0, f"max mismatch at 0x{index:04X}")
 
-    def test_invalid_limit_logs_warning(self):
-        import io
-        import logging
-
-        with open(SAMPLE_EDS) as f:
-            content = f.read()
-        invalid_eds = content.replace(
-            "LowLimit=0x02\nPDOMapping=0\n\n[3030]",
-            "LowLimit=INVALID\nPDOMapping=0\n\n[3030]",
-        )
-        with io.StringIO(invalid_eds) as buf:
-            buf.name = "mock.eds"
-            with self.assertLogs("canopen.objectdictionary.eds", level=logging.WARNING) as cm:
-                od = canopen.import_od(buf)
-        self.assertIsNone(od[0x3021].min)
-        self.assertTrue(any("LowLimit" in msg for msg in cm.output))
-
     def test_signed_int_from_hex(self):
         for data_type, test_cases in self.test_data.items():
             for test_case in test_cases:


### PR DESCRIPTION
Fixes incomplete and incorrect signed integer handling for `LowLimit`/`HighLimit` in EDS parsing and export, as noted in #352.

## Changes

### `_calc_bit_length` — extended to all SIGNED_TYPES

The existing function only handled INTEGER8/16/32/64. It now covers all 8 `SIGNED_TYPES` (INTEGER8/16/24/32/40/48/56/64) by deriving the bit width dynamically from `ODVariable.STRUCT_TYPES` instead of a hardcoded if/elif chain.

### `_signed_int_from_hex` — decimal and hex support, range validation

The parser now accepts both formats for `LowLimit`/`HighLimit`:
- Unsigned two's-complement hex (e.g. `0xFFFF` for INTEGER16 → `-1`)
- Signed decimal (e.g. `-32768` for INTEGER16 → `-32768`)

An explicit `ValueError` is raised if the value does not fit in the type's bit width. Previously, a value like `0xFFFF` for an 8-bit field would silently produce a wrong result.

### `_int_to_hex` — new helper for EDS integer serialization

Formats any integer as a valid EDS hex literal. Negative signed values are written as two's-complement unsigned hex (e.g. INTEGER32 `-1` → `0xFFFFFFFF`), which is the canonical EDS format. Used by `_revert_variable` and the export of `LowLimit`/`HighLimit`.

### `_revert_variable` — fix for negative integers

Previously used `f"0x{value:02X}"` unconditionally, which raises `ValueError` for negative values and broke export of any negative `DefaultValue`. Now delegates to `_int_to_hex`.

### Export of `LowLimit`/`HighLimit`

Previously written as raw Python integers (e.g. `-2147483648`). Now uses `_int_to_hex` to produce canonical unsigned two's-complement hex.

### Silent parse errors → `logger.warning`

All `except ValueError: pass` blocks in `build_variable` now log the field name, value, object name and index:
- `LowLimit`, `HighLimit`, `DefaultValue`, `ParameterValue`, `Factor`

Dead `try/except ValueError` around `Description` and `Unit` removed — `ConfigParser.get()` never raises `ValueError`.

## Tests

- Add `sample.eds` entries covering all four combinations of signed/unsigned × hex/decimal limits
- Refactor `test_record_with_limits` as a table-driven test with `subTest`
- Add `test_signed_int_from_hex_accepts_decimal` and `test_signed_int_from_hex_rejects_out_of_range`

Closes part of #352.