### PR TITLE
emcy: Catch callback exceptions and expand test coverage

### DIFF
--- a/canopen/emcy.py
+++ b/canopen/emcy.py
@@ -39,7 +39,10 @@ class EmcyConsumer:
             self.emcy_received.notify_all()
 
         for callback in self.callbacks:
-            callback(entry)
+            try:
+                callback(entry)
+            except Exception:
+                logger.exception("Exception in EMCY callback")
 
     def add_callback(self, callback: Callable[[EmcyError], None]):
         """Get notified on EMCY messages from this node.

--- a/test/test_emcy.py
+++ b/test/test_emcy.py
@@ -1,6 +1,7 @@
 import logging
 import threading
 import unittest
+from contextlib import contextmanager
 
 import can
 
@@ -9,6 +10,17 @@ import canopen.emcy
 
 
 TIMEOUT = 0.1
+
+
+@contextmanager
+def mock_rx_thread(consumer: canopen.emcy.EmcyConsumer, func):
+    t = threading.Thread(target=func)
+    try:
+        with consumer.emcy_received:
+            t.start()
+            yield t
+    finally:
+        t.join(TIMEOUT)
 
 
 class TestEmcy(unittest.TestCase):
@@ -86,40 +98,28 @@ class TestEmcy(unittest.TestCase):
         self.assertIsNone(emcy.wait(timeout=TIMEOUT))
 
         # Check unfiltered wait, on success.
-        t = threading.Thread(target=push_err)
-        with self.assertLogs(level=logging.INFO):
-            with emcy.emcy_received:
-                t.start()
-                err = emcy.wait(timeout=TIMEOUT)
-        t.join(TIMEOUT)
-        check_err(err)
+        with (
+            self.assertLogs(level=logging.INFO),
+            mock_rx_thread(emcy, push_err),
+        ):
+            check_err(emcy.wait(timeout=TIMEOUT))
 
         # Check filtered wait, on success.
-        t = threading.Thread(target=push_err)
-        with self.assertLogs(level=logging.INFO):
-            with emcy.emcy_received:
-                t.start()
-                err = emcy.wait(0x2001, TIMEOUT)
-        t.join(TIMEOUT)
-        check_err(err)
+        with (
+            self.assertLogs(level=logging.INFO),
+            mock_rx_thread(emcy, push_err),
+        ):
+            check_err(emcy.wait(0x2001, TIMEOUT))
 
         # Check filtered wait, on timeout.
-        t = threading.Thread(target=push_err)
-        with emcy.emcy_received:
-            t.start()
-            result = emcy.wait(0x9000, TIMEOUT)
-        t.join(TIMEOUT)
-        self.assertIsNone(result)
+        with mock_rx_thread(emcy, push_err):
+            self.assertIsNone(emcy.wait(0x9000, TIMEOUT))
 
         def push_reset():
             emcy.on_emcy(0x81, b'\x00\x00\x00\x00\x00\x00\x00\x00', 100)
 
-        t = threading.Thread(target=push_reset)
-        with emcy.emcy_received:
-            t.start()
-            result = emcy.wait(0x9000, TIMEOUT)
-        t.join(TIMEOUT)
-        self.assertIsNone(result)
+        with mock_rx_thread(emcy, push_reset):
+            self.assertIsNone(emcy.wait(0x9000, TIMEOUT))
 
     def test_emcy_consumer_multiple_callbacks(self):
         """Test adding multiple callbacks and their execution order."""
@@ -172,12 +172,12 @@ class TestEmcy(unittest.TestCase):
             emcy.on_emcy(0x81, b'\x01\x20\x01\x01\x02\x03\x04\x05', 100)
             emcy.on_emcy(0x81, b'\x02\x20\x01\x01\x02\x03\x04\x05', 101)
             emcy.on_emcy(0x81, b'\x03\x20\x01\x01\x02\x03\x04\x05', 102)
-        t = threading.Thread(target=push_multiple_errors)
-        with self.assertLogs(level=logging.INFO):
-            with emcy.emcy_received:
-                t.start()
-                err = emcy.wait(0x2003, timeout=TIMEOUT)
-        t.join(TIMEOUT)
+
+        with (
+            self.assertLogs(level=logging.INFO),
+            mock_rx_thread(emcy, push_multiple_errors),
+        ):
+            err = emcy.wait(0x2003, timeout=TIMEOUT)
         self.assertIsNotNone(err)
         self.assertEqual(err.code, 0x2003)
 
@@ -327,13 +327,14 @@ class TestEmcyIntegration(unittest.TestCase):
         """Test that producer and consumer work together."""
         received_errors = []
         self.consumer.add_callback(lambda err: received_errors.append(err))
-        t = threading.Thread(
-            target=lambda: self.producer.send(0x2001, 0x02, b'\x01\x02\x03\x04\x05'),
-        )
-        with self.assertLogs(level=logging.INFO):
-            t.start()
+        with (
+            self.assertLogs(level=logging.INFO),
+            mock_rx_thread(
+                self.consumer,
+                lambda: self.producer.send(0x2001, 0x02, b'\x01\x02\x03\x04\x05'),
+            ),
+        ):
             err = self.consumer.wait(0x2001, timeout=TIMEOUT)
-        t.join(TIMEOUT)
         self.assertIsNotNone(err)
         self.assertEqual(err.code, 0x2001)
         self.assertEqual(err.register, 0x02)
@@ -342,20 +343,20 @@ class TestEmcyIntegration(unittest.TestCase):
 
     def test_producer_reset_consumer_integration(self):
         """Test producer reset clears consumer active errors."""
-        t = threading.Thread(
-            target=lambda: self.producer.send(0x2001, 0x02, b'\x01\x02\x03\x04\x05'),
-        )
-        with self.assertLogs(level=logging.INFO):
-            t.start()
+        with (
+            self.assertLogs(level=logging.INFO),
+            mock_rx_thread(
+                self.consumer,
+                lambda: self.producer.send(0x2001, 0x02, b'\x01\x02\x03\x04\x05'),
+            ),
+        ):
             self.consumer.wait(0x2001, timeout=TIMEOUT)
-        t.join(TIMEOUT)
         self.assertEqual(len(self.consumer.active), 1)
-        t = threading.Thread(target=self.producer.reset)
-        with self.assertLogs(level=logging.INFO):
-            t.start()
-            err = self.consumer.wait(timeout=TIMEOUT)
-        t.join(TIMEOUT)
-        self.assertIsNotNone(err)
+        with (
+            self.assertLogs(level=logging.INFO),
+            mock_rx_thread(self.consumer, self.producer.reset),
+        ):
+            self.assertIsNotNone(self.consumer.wait(timeout=TIMEOUT))
         self.assertEqual(len(self.consumer.active), 0)
         self.assertEqual(len(self.consumer.log), 2)
 

--- a/test/test_emcy.py
+++ b/test/test_emcy.py
@@ -25,13 +25,12 @@ class TestEmcy(unittest.TestCase):
         self.assertAlmostEqual(err.timestamp, ts)
 
     def test_emcy_consumer_on_emcy(self):
-        # Make sure multiple callbacks receive the same information.
+        """Make sure multiple callbacks receive the same information."""
         acc1 = []
         acc2 = []
         self.emcy.add_callback(lambda err: acc1.append(err))
         self.emcy.add_callback(lambda err: acc2.append(err))
 
-        # Dispatch an EMCY datagram.
         self.emcy.on_emcy(0x81, b'\x01\x20\x02\x00\x01\x02\x03\x04', 1000)
 
         self.assertEqual(len(self.emcy.log), 1)
@@ -45,7 +44,6 @@ class TestEmcy(unittest.TestCase):
                 data=bytes([0, 1, 2, 3, 4]), ts=1000,
             )
 
-        # Dispatch a new EMCY datagram.
         self.emcy.on_emcy(0x81, b'\x10\x90\x01\x04\x03\x02\x01\x00', 2000)
         self.assertEqual(len(self.emcy.log), 2)
         self.assertEqual(len(self.emcy.active), 2)
@@ -58,7 +56,6 @@ class TestEmcy(unittest.TestCase):
                 data=bytes([4, 3, 2, 1, 0]), ts=2000,
             )
 
-        # Dispatch an EMCY reset.
         self.emcy.on_emcy(0x81, b'\x00\x00\x00\x00\x00\x00\x00\x00', 2000)
         self.assertEqual(len(self.emcy.log), 3)
         self.assertEqual(len(self.emcy.active), 0)
@@ -123,6 +120,65 @@ class TestEmcy(unittest.TestCase):
             t.start()
             self.assertIsNone(self.emcy.wait(0x9000, TIMEOUT))
 
+    def test_emcy_consumer_initialization(self):
+        consumer = canopen.emcy.EmcyConsumer()
+        self.assertEqual(consumer.log, [])
+        self.assertEqual(consumer.active, [])
+        self.assertEqual(consumer.callbacks, [])
+
+    def test_emcy_consumer_multiple_callbacks(self):
+        """Test adding multiple callbacks and their execution order."""
+        call_order = []
+        self.emcy.add_callback(lambda err: call_order.append('callback1'))
+        self.emcy.add_callback(lambda err: call_order.append('callback2'))
+        self.emcy.add_callback(lambda err: call_order.append('callback3'))
+        self.emcy.on_emcy(0x81, b'\x01\x20\x02\x00\x01\x02\x03\x04', 1000)
+        self.assertEqual(call_order, ['callback1', 'callback2', 'callback3'])
+
+    def test_emcy_consumer_callback_exception_handling(self):
+        """Test that callback exceptions don't break other callbacks or the system."""
+        successful_callbacks = []
+        self.emcy.add_callback(lambda err: successful_callbacks.append('success1'))
+        self.emcy.add_callback(
+            lambda err: exec('raise ValueError("Test exception in callback")')
+        )
+        self.emcy.add_callback(lambda err: successful_callbacks.append('success2'))
+        self.emcy.on_emcy(0x81, b'\x01\x20\x02\x00\x01\x02\x03\x04', 1000)
+        self.assertEqual(successful_callbacks, ['success1', 'success2'])
+
+    def test_emcy_consumer_error_reset_variants(self):
+        """Test different error reset code patterns."""
+        self.emcy.on_emcy(0x81, b'\x01\x20\x02\x00\x01\x02\x03\x04', 1000)
+        self.emcy.on_emcy(0x81, b'\x10\x90\x01\x04\x03\x02\x01\x00', 2000)
+        self.assertEqual(len(self.emcy.active), 2)
+        self.emcy.on_emcy(0x81, b'\x00\x00\x00\x00\x00\x00\x00\x00', 3000)
+        self.assertEqual(len(self.emcy.active), 0)
+        self.emcy.on_emcy(0x81, b'\x01\x30\x02\x00\x01\x02\x03\x04', 4000)
+        self.assertEqual(len(self.emcy.active), 1)
+        self.emcy.on_emcy(0x81, b'\x99\x00\x01\x00\x00\x00\x00\x00', 5000)
+        self.assertEqual(len(self.emcy.active), 0)
+
+    def test_emcy_consumer_wait_timeout_edge_cases(self):
+        """Test wait method with various timeout scenarios."""
+        result = self.emcy.wait(timeout=0)
+        self.assertIsNone(result)
+        result = self.emcy.wait(timeout=0.001)
+        self.assertIsNone(result)
+
+    def test_emcy_consumer_wait_concurrent_errors(self):
+        """Test wait method when multiple errors arrive concurrently."""
+        def push_multiple_errors():
+            self.emcy.on_emcy(0x81, b'\x01\x20\x01\x01\x02\x03\x04\x05', 100)
+            self.emcy.on_emcy(0x81, b'\x02\x20\x01\x01\x02\x03\x04\x05', 101)
+            self.emcy.on_emcy(0x81, b'\x03\x20\x01\x01\x02\x03\x04\x05', 102)
+        t = threading.Timer(TIMEOUT / 2, push_multiple_errors)
+        with self.assertLogs(level=logging.INFO):
+            t.start()
+            err = self.emcy.wait(0x2003, timeout=TIMEOUT)
+        t.join(TIMEOUT)
+        self.assertIsNotNone(err)
+        self.assertEqual(err.code, 0x2003)
+
 
 class TestEmcyError(unittest.TestCase):
     def test_emcy_error(self):
@@ -180,6 +236,26 @@ class TestEmcyError(unittest.TestCase):
         check(0xff00, "Device Specific")
         check(0xffff, "Device Specific")
 
+    def test_emcy_error_initialization_types(self):
+        """Test EmcyError initialization with various data types."""
+        error = EmcyError(0x1000, 0, b'', 123.456)
+        self.assertEqual(error.code, 0x1000)
+        self.assertEqual(error.register, 0)
+        self.assertEqual(error.data, b'')
+        self.assertEqual(error.timestamp, 123.456)
+        error = EmcyError(0xFFFF, 0xFF, b'\xFF' * 5, float('inf'))
+        self.assertEqual(error.code, 0xFFFF)
+        self.assertEqual(error.register, 0xFF)
+        self.assertEqual(error.data, b'\xFF' * 5)
+        self.assertEqual(error.timestamp, float('inf'))
+
+    def test_emcy_error_str_edge_cases(self):
+        for code in (0x0000, 0x0001, 0x0100, 0xFFFF):
+            error = EmcyError(code, 0, b'', 1000)
+            s = str(error)
+            self.assertIsInstance(s, str)
+            self.assertIn(f"0x{code:04X}", s)
+
 
 class TestEmcyProducer(unittest.TestCase):
     def setUp(self):
@@ -219,6 +295,91 @@ class TestEmcyProducer(unittest.TestCase):
         check(res=b'\x00\x00\x00\x00\x00\x00\x00\x00')
         check(3, res=b'\x00\x00\x03\x00\x00\x00\x00\x00')
         check(3, b"\xaa\xbb", res=b'\x00\x00\x03\xaa\xbb\x00\x00\x00')
+
+    def test_emcy_producer_initialization(self):
+        producer = canopen.emcy.EmcyProducer(0x123)
+        self.assertEqual(producer.cob_id, 0x123)
+        self.assertIsNotNone(producer.network)
+
+    def test_emcy_producer_send_edge_cases(self):
+        self.emcy.send(0xFFFF, 0xFF, b'\xFF\xFF\xFF\xFF\xFF')
+        self.check_response(b'\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF')
+        self.emcy.send(0x0000, 0x00)
+        self.check_response(b'\x00\x00\x00\x00\x00\x00\x00\x00')
+        self.emcy.send(0x1234, 0x56, b'\xAB\xCD')
+        self.check_response(b'\x34\x12\x56\xAB\xCD\x00\x00\x00')
+        self.emcy.send(0x1234, 0x56, b'\xAB\xCD\xEF\x12\x34')
+        self.check_response(b'\x34\x12\x56\xAB\xCD\xEF\x12\x34')
+
+    def test_emcy_producer_reset_edge_cases(self):
+        self.emcy.reset(0xFF)
+        self.check_response(b'\x00\x00\xFF\x00\x00\x00\x00\x00')
+        self.emcy.reset(0xFF, b'\xFF\xFF\xFF\xFF\xFF')
+        self.check_response(b'\x00\x00\xFF\xFF\xFF\xFF\xFF\xFF')
+        self.emcy.reset(0x12, b'\xAB\xCD')
+        self.check_response(b'\x00\x00\x12\xAB\xCD\x00\x00\x00')
+
+
+class TestEmcyIntegration(unittest.TestCase):
+    """Integration tests for EMCY producer and consumer."""
+
+    def setUp(self):
+        self.txbus = can.Bus(interface="virtual")
+        self.rxbus = can.Bus(interface="virtual")
+        self.net = canopen.Network(self.txbus)
+        self.net.NOTIFIER_SHUTDOWN_TIMEOUT = 0.0
+        self.net.connect()
+        self.rx_net = canopen.Network(self.rxbus)
+        self.rx_net.NOTIFIER_SHUTDOWN_TIMEOUT = 0.0
+        self.rx_net.connect()
+        self.producer = canopen.emcy.EmcyProducer(0x081)
+        self.producer.network = self.net
+        self.consumer = canopen.emcy.EmcyConsumer()
+        self.rx_net.subscribe(0x081, self.consumer.on_emcy)
+
+    def tearDown(self):
+        self.net.disconnect()
+        self.rx_net.disconnect()
+        self.txbus.shutdown()
+        self.rxbus.shutdown()
+
+    def test_producer_consumer_integration(self):
+        """Test that producer and consumer work together."""
+        received_errors = []
+        self.consumer.add_callback(lambda err: received_errors.append(err))
+        t = threading.Timer(
+            TIMEOUT / 2,
+            lambda: self.producer.send(0x2001, 0x02, b'\x01\x02\x03\x04\x05'),
+        )
+        with self.assertLogs(level=logging.INFO):
+            t.start()
+            err = self.consumer.wait(0x2001, timeout=TIMEOUT)
+        t.join(TIMEOUT)
+        self.assertIsNotNone(err)
+        self.assertEqual(err.code, 0x2001)
+        self.assertEqual(err.register, 0x02)
+        self.assertEqual(err.data, b'\x01\x02\x03\x04\x05')
+        self.assertEqual(received_errors, [err])
+
+    def test_producer_reset_consumer_integration(self):
+        """Test producer reset clears consumer active errors."""
+        t = threading.Timer(
+            TIMEOUT / 2,
+            lambda: self.producer.send(0x2001, 0x02, b'\x01\x02\x03\x04\x05'),
+        )
+        with self.assertLogs(level=logging.INFO):
+            t.start()
+            self.consumer.wait(0x2001, timeout=TIMEOUT)
+        t.join(TIMEOUT)
+        self.assertEqual(len(self.consumer.active), 1)
+        t = threading.Timer(TIMEOUT / 2, self.producer.reset)
+        with self.assertLogs(level=logging.INFO):
+            t.start()
+            err = self.consumer.wait(timeout=TIMEOUT)
+        t.join(TIMEOUT)
+        self.assertIsNotNone(err)
+        self.assertEqual(len(self.consumer.active), 0)
+        self.assertEqual(len(self.consumer.log), 2)
 
 
 if __name__ == "__main__":

--- a/test/test_emcy.py
+++ b/test/test_emcy.py
@@ -6,7 +6,6 @@ from contextlib import contextmanager
 import can
 
 import canopen
-import canopen.emcy
 
 
 TIMEOUT = 0.1
@@ -313,6 +312,8 @@ class TestEmcyIntegration(unittest.TestCase):
         self.rx_net.connect()
         self.producer = canopen.emcy.EmcyProducer(0x081)
         self.producer.network = self.net
+        self.consumer = canopen.emcy.EmcyConsumer()
+        self.rx_net.subscribe(0x081, self.consumer.on_emcy)
 
     def tearDown(self):
         self.net.disconnect()
@@ -322,18 +323,16 @@ class TestEmcyIntegration(unittest.TestCase):
 
     def test_producer_consumer_integration(self):
         """Test that producer and consumer work together."""
-        consumer = canopen.emcy.EmcyConsumer()
-        self.rx_net.subscribe(0x081, consumer.on_emcy)
         received_errors = []
-        consumer.add_callback(lambda err: received_errors.append(err))
+        self.consumer.add_callback(lambda err: received_errors.append(err))
         with (
             self.assertLogs(level=logging.INFO),
             mock_rx_thread(
-                consumer,
+                self.consumer,
                 lambda: self.producer.send(0x2001, 0x02, b'\x01\x02\x03\x04\x05'),
             ),
         ):
-            err = consumer.wait(0x2001, timeout=TIMEOUT)
+            err = self.consumer.wait(0x2001, timeout=TIMEOUT)
         self.assertIsNotNone(err)
         self.assertEqual(err.code, 0x2001)
         self.assertEqual(err.register, 0x02)
@@ -342,24 +341,22 @@ class TestEmcyIntegration(unittest.TestCase):
 
     def test_producer_reset_consumer_integration(self):
         """Test producer reset clears consumer active errors."""
-        consumer = canopen.emcy.EmcyConsumer()
-        self.rx_net.subscribe(0x081, consumer.on_emcy)
         with (
             self.assertLogs(level=logging.INFO),
             mock_rx_thread(
-                consumer,
+                self.consumer,
                 lambda: self.producer.send(0x2001, 0x02, b'\x01\x02\x03\x04\x05'),
             ),
         ):
-            consumer.wait(0x2001, timeout=TIMEOUT)
-        self.assertEqual(len(consumer.active), 1)
+            self.consumer.wait(0x2001, timeout=TIMEOUT)
+        self.assertEqual(len(self.consumer.active), 1)
         with (
             self.assertLogs(level=logging.INFO),
-            mock_rx_thread(consumer, self.producer.reset),
+            mock_rx_thread(self.consumer, self.producer.reset),
         ):
-            self.assertIsNotNone(consumer.wait(timeout=TIMEOUT))
-        self.assertEqual(len(consumer.active), 0)
-        self.assertEqual(len(consumer.log), 2)
+            self.assertIsNotNone(self.consumer.wait(timeout=TIMEOUT))
+        self.assertEqual(len(self.consumer.active), 0)
+        self.assertEqual(len(self.consumer.log), 2)
 
 
 if __name__ == "__main__":

--- a/test/test_emcy.py
+++ b/test/test_emcy.py
@@ -13,9 +13,6 @@ TIMEOUT = 0.1
 
 class TestEmcy(unittest.TestCase):
 
-    def setUp(self):
-        self.emcy = canopen.emcy.EmcyConsumer()
-
     def check_error(self, err, code, reg, data, ts):
         self.assertIsInstance(err, canopen.emcy.EmcyError)
         self.assertIsInstance(err, Exception)
@@ -26,53 +23,57 @@ class TestEmcy(unittest.TestCase):
 
     def test_emcy_consumer_on_emcy(self):
         """Make sure multiple callbacks receive the same information."""
+        emcy = canopen.emcy.EmcyConsumer()
         acc1 = []
         acc2 = []
-        self.emcy.add_callback(lambda err: acc1.append(err))
-        self.emcy.add_callback(lambda err: acc2.append(err))
+        emcy.add_callback(lambda err: acc1.append(err))
+        emcy.add_callback(lambda err: acc2.append(err))
 
-        self.emcy.on_emcy(0x81, b'\x01\x20\x02\x00\x01\x02\x03\x04', 1000)
+        emcy.on_emcy(0x81, b'\x01\x20\x02\x00\x01\x02\x03\x04', 1000)
 
-        self.assertEqual(len(self.emcy.log), 1)
-        self.assertEqual(len(self.emcy.active), 1)
+        self.assertEqual(len(emcy.log), 1)
+        self.assertEqual(len(emcy.active), 1)
 
-        error = self.emcy.log[0]
-        self.assertEqual(self.emcy.active[0], error)
+        error = emcy.log[0]
+        self.assertEqual(emcy.active[0], error)
         for err in error, acc1[0], acc2[0]:
             self.check_error(
                 error, code=0x2001, reg=0x02,
                 data=bytes([0, 1, 2, 3, 4]), ts=1000,
             )
 
-        self.emcy.on_emcy(0x81, b'\x10\x90\x01\x04\x03\x02\x01\x00', 2000)
-        self.assertEqual(len(self.emcy.log), 2)
-        self.assertEqual(len(self.emcy.active), 2)
+        emcy.on_emcy(0x81, b'\x10\x90\x01\x04\x03\x02\x01\x00', 2000)
+        self.assertEqual(len(emcy.log), 2)
+        self.assertEqual(len(emcy.active), 2)
 
-        error = self.emcy.log[1]
-        self.assertEqual(self.emcy.active[1], error)
+        error = emcy.log[1]
+        self.assertEqual(emcy.active[1], error)
         for err in error, acc1[1], acc2[1]:
             self.check_error(
                 error, code=0x9010, reg=0x01,
                 data=bytes([4, 3, 2, 1, 0]), ts=2000,
             )
 
-        self.emcy.on_emcy(0x81, b'\x00\x00\x00\x00\x00\x00\x00\x00', 2000)
-        self.assertEqual(len(self.emcy.log), 3)
-        self.assertEqual(len(self.emcy.active), 0)
+        emcy.on_emcy(0x81, b'\x00\x00\x00\x00\x00\x00\x00\x00', 2000)
+        self.assertEqual(len(emcy.log), 3)
+        self.assertEqual(len(emcy.active), 0)
 
     def test_emcy_consumer_reset(self):
-        self.emcy.on_emcy(0x81, b'\x01\x20\x02\x00\x01\x02\x03\x04', 1000)
-        self.emcy.on_emcy(0x81, b'\x10\x90\x01\x04\x03\x02\x01\x00', 2000)
-        self.assertEqual(len(self.emcy.log), 2)
-        self.assertEqual(len(self.emcy.active), 2)
+        emcy = canopen.emcy.EmcyConsumer()
+        emcy.on_emcy(0x81, b'\x01\x20\x02\x00\x01\x02\x03\x04', 1000)
+        emcy.on_emcy(0x81, b'\x10\x90\x01\x04\x03\x02\x01\x00', 2000)
+        self.assertEqual(len(emcy.log), 2)
+        self.assertEqual(len(emcy.active), 2)
 
-        self.emcy.reset()
-        self.assertEqual(len(self.emcy.log), 0)
-        self.assertEqual(len(self.emcy.active), 0)
+        emcy.reset()
+        self.assertEqual(len(emcy.log), 0)
+        self.assertEqual(len(emcy.active), 0)
 
     def test_emcy_consumer_wait(self):
+        emcy = canopen.emcy.EmcyConsumer()
+
         def push_err():
-            self.emcy.on_emcy(0x81, b'\x01\x20\x01\x01\x02\x03\x04\x05', 100)
+            emcy.on_emcy(0x81, b'\x01\x20\x01\x01\x02\x03\x04\x05', 100)
 
         def check_err(err):
             self.assertIsNotNone(err)
@@ -82,41 +83,41 @@ class TestEmcy(unittest.TestCase):
             )
 
         # Check unfiltered wait, on timeout.
-        self.assertIsNone(self.emcy.wait(timeout=TIMEOUT))
+        self.assertIsNone(emcy.wait(timeout=TIMEOUT))
 
         # Check unfiltered wait, on success.
         t = threading.Thread(target=push_err)
         with self.assertLogs(level=logging.INFO):
-            with self.emcy.emcy_received:
+            with emcy.emcy_received:
                 t.start()
-                err = self.emcy.wait(timeout=TIMEOUT)
+                err = emcy.wait(timeout=TIMEOUT)
         t.join(TIMEOUT)
         check_err(err)
 
         # Check filtered wait, on success.
         t = threading.Thread(target=push_err)
         with self.assertLogs(level=logging.INFO):
-            with self.emcy.emcy_received:
+            with emcy.emcy_received:
                 t.start()
-                err = self.emcy.wait(0x2001, TIMEOUT)
+                err = emcy.wait(0x2001, TIMEOUT)
         t.join(TIMEOUT)
         check_err(err)
 
         # Check filtered wait, on timeout.
         t = threading.Thread(target=push_err)
-        with self.emcy.emcy_received:
+        with emcy.emcy_received:
             t.start()
-            result = self.emcy.wait(0x9000, TIMEOUT)
+            result = emcy.wait(0x9000, TIMEOUT)
         t.join(TIMEOUT)
         self.assertIsNone(result)
 
         def push_reset():
-            self.emcy.on_emcy(0x81, b'\x00\x00\x00\x00\x00\x00\x00\x00', 100)
+            emcy.on_emcy(0x81, b'\x00\x00\x00\x00\x00\x00\x00\x00', 100)
 
         t = threading.Thread(target=push_reset)
-        with self.emcy.emcy_received:
+        with emcy.emcy_received:
             t.start()
-            result = self.emcy.wait(0x9000, TIMEOUT)
+            result = emcy.wait(0x9000, TIMEOUT)
         t.join(TIMEOUT)
         self.assertIsNone(result)
 
@@ -144,34 +145,38 @@ class TestEmcy(unittest.TestCase):
 
     def test_emcy_consumer_error_reset_variants(self):
         """Test different error reset code patterns."""
-        self.emcy.on_emcy(0x81, b'\x01\x20\x02\x00\x01\x02\x03\x04', 1000)
-        self.emcy.on_emcy(0x81, b'\x10\x90\x01\x04\x03\x02\x01\x00', 2000)
-        self.assertEqual(len(self.emcy.active), 2)
-        self.emcy.on_emcy(0x81, b'\x00\x00\x00\x00\x00\x00\x00\x00', 3000)
-        self.assertEqual(len(self.emcy.active), 0)
-        self.emcy.on_emcy(0x81, b'\x01\x30\x02\x00\x01\x02\x03\x04', 4000)
-        self.assertEqual(len(self.emcy.active), 1)
-        self.emcy.on_emcy(0x81, b'\x99\x00\x01\x00\x00\x00\x00\x00', 5000)
-        self.assertEqual(len(self.emcy.active), 0)
+        emcy = canopen.emcy.EmcyConsumer()
+        emcy.on_emcy(0x81, b'\x01\x20\x02\x00\x01\x02\x03\x04', 1000)
+        emcy.on_emcy(0x81, b'\x10\x90\x01\x04\x03\x02\x01\x00', 2000)
+        self.assertEqual(len(emcy.active), 2)
+        emcy.on_emcy(0x81, b'\x00\x00\x00\x00\x00\x00\x00\x00', 3000)
+        self.assertEqual(len(emcy.active), 0)
+        emcy.on_emcy(0x81, b'\x01\x30\x02\x00\x01\x02\x03\x04', 4000)
+        self.assertEqual(len(emcy.active), 1)
+        emcy.on_emcy(0x81, b'\x99\x00\x01\x00\x00\x00\x00\x00', 5000)
+        self.assertEqual(len(emcy.active), 0)
 
     def test_emcy_consumer_wait_timeout_edge_cases(self):
         """Test wait method with various timeout scenarios."""
-        result = self.emcy.wait(timeout=0)
+        emcy = canopen.emcy.EmcyConsumer()
+        result = emcy.wait(timeout=0)
         self.assertIsNone(result)
-        result = self.emcy.wait(timeout=0.001)
+        result = emcy.wait(timeout=0.001)
         self.assertIsNone(result)
 
     def test_emcy_consumer_wait_concurrent_errors(self):
         """Test wait method when multiple errors arrive concurrently."""
+        emcy = canopen.emcy.EmcyConsumer()
+
         def push_multiple_errors():
-            self.emcy.on_emcy(0x81, b'\x01\x20\x01\x01\x02\x03\x04\x05', 100)
-            self.emcy.on_emcy(0x81, b'\x02\x20\x01\x01\x02\x03\x04\x05', 101)
-            self.emcy.on_emcy(0x81, b'\x03\x20\x01\x01\x02\x03\x04\x05', 102)
+            emcy.on_emcy(0x81, b'\x01\x20\x01\x01\x02\x03\x04\x05', 100)
+            emcy.on_emcy(0x81, b'\x02\x20\x01\x01\x02\x03\x04\x05', 101)
+            emcy.on_emcy(0x81, b'\x03\x20\x01\x01\x02\x03\x04\x05', 102)
         t = threading.Thread(target=push_multiple_errors)
         with self.assertLogs(level=logging.INFO):
-            with self.emcy.emcy_received:
+            with emcy.emcy_received:
                 t.start()
-                err = self.emcy.wait(0x2003, timeout=TIMEOUT)
+                err = emcy.wait(0x2003, timeout=TIMEOUT)
         t.join(TIMEOUT)
         self.assertIsNotNone(err)
         self.assertEqual(err.code, 0x2003)

--- a/test/test_emcy.py
+++ b/test/test_emcy.py
@@ -1,12 +1,11 @@
 import logging
 import threading
 import unittest
-from contextlib import contextmanager
 
 import can
 
 import canopen
-from canopen.emcy import EmcyError
+import canopen.emcy
 
 
 TIMEOUT = 0.1
@@ -18,7 +17,7 @@ class TestEmcy(unittest.TestCase):
         self.emcy = canopen.emcy.EmcyConsumer()
 
     def check_error(self, err, code, reg, data, ts):
-        self.assertIsInstance(err, EmcyError)
+        self.assertIsInstance(err, canopen.emcy.EmcyError)
         self.assertIsInstance(err, Exception)
         self.assertEqual(err.code, code)
         self.assertEqual(err.register, reg)
@@ -72,8 +71,6 @@ class TestEmcy(unittest.TestCase):
         self.assertEqual(len(self.emcy.active), 0)
 
     def test_emcy_consumer_wait(self):
-        PAUSE = TIMEOUT / 2
-
         def push_err():
             self.emcy.on_emcy(0x81, b'\x01\x20\x01\x01\x02\x03\x04\x05', 100)
 
@@ -84,67 +81,65 @@ class TestEmcy(unittest.TestCase):
                 data=bytes([1, 2, 3, 4, 5]), ts=100,
             )
 
-        @contextmanager
-        def timer(func):
-            t = threading.Timer(PAUSE, func)
-            try:
-                yield t
-            finally:
-                t.join(TIMEOUT)
-
         # Check unfiltered wait, on timeout.
         self.assertIsNone(self.emcy.wait(timeout=TIMEOUT))
 
         # Check unfiltered wait, on success.
-        with timer(push_err) as t:
-            with self.assertLogs(level=logging.INFO):
+        t = threading.Thread(target=push_err)
+        with self.assertLogs(level=logging.INFO):
+            with self.emcy.emcy_received:
                 t.start()
                 err = self.emcy.wait(timeout=TIMEOUT)
+        t.join(TIMEOUT)
         check_err(err)
 
         # Check filtered wait, on success.
-        with timer(push_err) as t:
-            with self.assertLogs(level=logging.INFO):
+        t = threading.Thread(target=push_err)
+        with self.assertLogs(level=logging.INFO):
+            with self.emcy.emcy_received:
                 t.start()
                 err = self.emcy.wait(0x2001, TIMEOUT)
+        t.join(TIMEOUT)
         check_err(err)
 
         # Check filtered wait, on timeout.
-        with timer(push_err) as t:
+        t = threading.Thread(target=push_err)
+        with self.emcy.emcy_received:
             t.start()
-            self.assertIsNone(self.emcy.wait(0x9000, TIMEOUT))
+            result = self.emcy.wait(0x9000, TIMEOUT)
+        t.join(TIMEOUT)
+        self.assertIsNone(result)
 
         def push_reset():
             self.emcy.on_emcy(0x81, b'\x00\x00\x00\x00\x00\x00\x00\x00', 100)
 
-        with timer(push_reset) as t:
+        t = threading.Thread(target=push_reset)
+        with self.emcy.emcy_received:
             t.start()
-            self.assertIsNone(self.emcy.wait(0x9000, TIMEOUT))
-
-    def test_emcy_consumer_initialization(self):
-        consumer = canopen.emcy.EmcyConsumer()
-        self.assertEqual(consumer.log, [])
-        self.assertEqual(consumer.active, [])
-        self.assertEqual(consumer.callbacks, [])
+            result = self.emcy.wait(0x9000, TIMEOUT)
+        t.join(TIMEOUT)
+        self.assertIsNone(result)
 
     def test_emcy_consumer_multiple_callbacks(self):
         """Test adding multiple callbacks and their execution order."""
+        emcy = canopen.emcy.EmcyConsumer()
         call_order = []
-        self.emcy.add_callback(lambda err: call_order.append('callback1'))
-        self.emcy.add_callback(lambda err: call_order.append('callback2'))
-        self.emcy.add_callback(lambda err: call_order.append('callback3'))
-        self.emcy.on_emcy(0x81, b'\x01\x20\x02\x00\x01\x02\x03\x04', 1000)
+        emcy.add_callback(lambda err: call_order.append('callback1'))
+        emcy.add_callback(lambda err: call_order.append('callback2'))
+        emcy.add_callback(lambda err: call_order.append('callback3'))
+        emcy.on_emcy(0x81, b'\x01\x20\x02\x00\x01\x02\x03\x04', 1000)
         self.assertEqual(call_order, ['callback1', 'callback2', 'callback3'])
 
     def test_emcy_consumer_callback_exception_handling(self):
         """Test that callback exceptions don't break other callbacks or the system."""
+        emcy = canopen.emcy.EmcyConsumer()
         successful_callbacks = []
-        self.emcy.add_callback(lambda err: successful_callbacks.append('success1'))
-        self.emcy.add_callback(
+        emcy.add_callback(lambda err: successful_callbacks.append('success1'))
+        emcy.add_callback(
             lambda err: exec('raise ValueError("Test exception in callback")')
         )
-        self.emcy.add_callback(lambda err: successful_callbacks.append('success2'))
-        self.emcy.on_emcy(0x81, b'\x01\x20\x02\x00\x01\x02\x03\x04', 1000)
+        emcy.add_callback(lambda err: successful_callbacks.append('success2'))
+        emcy.on_emcy(0x81, b'\x01\x20\x02\x00\x01\x02\x03\x04', 1000)
         self.assertEqual(successful_callbacks, ['success1', 'success2'])
 
     def test_emcy_consumer_error_reset_variants(self):
@@ -172,10 +167,11 @@ class TestEmcy(unittest.TestCase):
             self.emcy.on_emcy(0x81, b'\x01\x20\x01\x01\x02\x03\x04\x05', 100)
             self.emcy.on_emcy(0x81, b'\x02\x20\x01\x01\x02\x03\x04\x05', 101)
             self.emcy.on_emcy(0x81, b'\x03\x20\x01\x01\x02\x03\x04\x05', 102)
-        t = threading.Timer(TIMEOUT / 2, push_multiple_errors)
+        t = threading.Thread(target=push_multiple_errors)
         with self.assertLogs(level=logging.INFO):
-            t.start()
-            err = self.emcy.wait(0x2003, timeout=TIMEOUT)
+            with self.emcy.emcy_received:
+                t.start()
+                err = self.emcy.wait(0x2003, timeout=TIMEOUT)
         t.join(TIMEOUT)
         self.assertIsNotNone(err)
         self.assertEqual(err.code, 0x2003)
@@ -184,7 +180,7 @@ class TestEmcy(unittest.TestCase):
 class TestEmcyError(unittest.TestCase):
 
     def test_emcy_error(self):
-        error = EmcyError(0x2001, 0x02, b'\x00\x01\x02\x03\x04', 1000)
+        error = canopen.emcy.EmcyError(0x2001, 0x02, b'\x00\x01\x02\x03\x04', 1000)
         self.assertEqual(error.code, 0x2001)
         self.assertEqual(error.data, b'\x00\x01\x02\x03\x04')
         self.assertEqual(error.register, 2)
@@ -192,7 +188,7 @@ class TestEmcyError(unittest.TestCase):
 
     def test_emcy_str(self):
         def check(code, expected):
-            err = EmcyError(code, 1, b'', 1000)
+            err = canopen.emcy.EmcyError(code, 1, b'', 1000)
             actual = str(err)
             self.assertEqual(actual, expected)
 
@@ -203,7 +199,7 @@ class TestEmcyError(unittest.TestCase):
 
     def test_emcy_get_desc(self):
         def check(code, expected):
-            err = EmcyError(code, 1, b'', 1000)
+            err = canopen.emcy.EmcyError(code, 1, b'', 1000)
             actual = err.get_desc()
             self.assertEqual(actual, expected)
 
@@ -238,25 +234,6 @@ class TestEmcyError(unittest.TestCase):
         check(0xff00, "Device Specific")
         check(0xffff, "Device Specific")
 
-    def test_emcy_error_initialization_types(self):
-        """Test EmcyError initialization with various data types."""
-        error = EmcyError(0x1000, 0, b'', 123.456)
-        self.assertEqual(error.code, 0x1000)
-        self.assertEqual(error.register, 0)
-        self.assertEqual(error.data, b'')
-        self.assertEqual(error.timestamp, 123.456)
-        error = EmcyError(0xFFFF, 0xFF, b'\xFF' * 5, float('inf'))
-        self.assertEqual(error.code, 0xFFFF)
-        self.assertEqual(error.register, 0xFF)
-        self.assertEqual(error.data, b'\xFF' * 5)
-        self.assertEqual(error.timestamp, float('inf'))
-
-    def test_emcy_error_str_edge_cases(self):
-        for code in (0x0000, 0x0001, 0x0100, 0xFFFF):
-            error = EmcyError(code, 0, b'', 1000)
-            s = str(error)
-            self.assertIsInstance(s, str)
-            self.assertIn(f"0x{code:04X}", s)
 
 
 class TestEmcyProducer(unittest.TestCase):
@@ -277,7 +254,7 @@ class TestEmcyProducer(unittest.TestCase):
 
     def check_response(self, expected):
         msg = self.rxbus.recv(TIMEOUT)
-        self.assertIsNotNone(msg)
+        assert msg is not None
         actual = msg.data
         self.assertEqual(actual, expected)
 
@@ -298,11 +275,6 @@ class TestEmcyProducer(unittest.TestCase):
         check(res=b'\x00\x00\x00\x00\x00\x00\x00\x00')
         check(3, res=b'\x00\x00\x03\x00\x00\x00\x00\x00')
         check(3, b"\xaa\xbb", res=b'\x00\x00\x03\xaa\xbb\x00\x00\x00')
-
-    def test_emcy_producer_initialization(self):
-        producer = canopen.emcy.EmcyProducer(0x123)
-        self.assertEqual(producer.cob_id, 0x123)
-        self.assertIsNotNone(producer.network)
 
     def test_emcy_producer_send_edge_cases(self):
         self.emcy.send(0xFFFF, 0xFF, b'\xFF\xFF\xFF\xFF\xFF')
@@ -350,9 +322,8 @@ class TestEmcyIntegration(unittest.TestCase):
         """Test that producer and consumer work together."""
         received_errors = []
         self.consumer.add_callback(lambda err: received_errors.append(err))
-        t = threading.Timer(
-            TIMEOUT / 2,
-            lambda: self.producer.send(0x2001, 0x02, b'\x01\x02\x03\x04\x05'),
+        t = threading.Thread(
+            target=lambda: self.producer.send(0x2001, 0x02, b'\x01\x02\x03\x04\x05'),
         )
         with self.assertLogs(level=logging.INFO):
             t.start()
@@ -366,16 +337,15 @@ class TestEmcyIntegration(unittest.TestCase):
 
     def test_producer_reset_consumer_integration(self):
         """Test producer reset clears consumer active errors."""
-        t = threading.Timer(
-            TIMEOUT / 2,
-            lambda: self.producer.send(0x2001, 0x02, b'\x01\x02\x03\x04\x05'),
+        t = threading.Thread(
+            target=lambda: self.producer.send(0x2001, 0x02, b'\x01\x02\x03\x04\x05'),
         )
         with self.assertLogs(level=logging.INFO):
             t.start()
             self.consumer.wait(0x2001, timeout=TIMEOUT)
         t.join(TIMEOUT)
         self.assertEqual(len(self.consumer.active), 1)
-        t = threading.Timer(TIMEOUT / 2, self.producer.reset)
+        t = threading.Thread(target=self.producer.reset)
         with self.assertLogs(level=logging.INFO):
             t.start()
             err = self.consumer.wait(timeout=TIMEOUT)

--- a/test/test_emcy.py
+++ b/test/test_emcy.py
@@ -6,6 +6,7 @@ from contextlib import contextmanager
 import can
 
 import canopen
+import canopen.emcy
 
 
 TIMEOUT = 0.1
@@ -312,8 +313,6 @@ class TestEmcyIntegration(unittest.TestCase):
         self.rx_net.connect()
         self.producer = canopen.emcy.EmcyProducer(0x081)
         self.producer.network = self.net
-        self.consumer = canopen.emcy.EmcyConsumer()
-        self.rx_net.subscribe(0x081, self.consumer.on_emcy)
 
     def tearDown(self):
         self.net.disconnect()
@@ -323,16 +322,18 @@ class TestEmcyIntegration(unittest.TestCase):
 
     def test_producer_consumer_integration(self):
         """Test that producer and consumer work together."""
+        consumer = canopen.emcy.EmcyConsumer()
+        self.rx_net.subscribe(0x081, consumer.on_emcy)
         received_errors = []
-        self.consumer.add_callback(lambda err: received_errors.append(err))
+        consumer.add_callback(lambda err: received_errors.append(err))
         with (
             self.assertLogs(level=logging.INFO),
             mock_rx_thread(
-                self.consumer,
+                consumer,
                 lambda: self.producer.send(0x2001, 0x02, b'\x01\x02\x03\x04\x05'),
             ),
         ):
-            err = self.consumer.wait(0x2001, timeout=TIMEOUT)
+            err = consumer.wait(0x2001, timeout=TIMEOUT)
         self.assertIsNotNone(err)
         self.assertEqual(err.code, 0x2001)
         self.assertEqual(err.register, 0x02)
@@ -341,22 +342,24 @@ class TestEmcyIntegration(unittest.TestCase):
 
     def test_producer_reset_consumer_integration(self):
         """Test producer reset clears consumer active errors."""
+        consumer = canopen.emcy.EmcyConsumer()
+        self.rx_net.subscribe(0x081, consumer.on_emcy)
         with (
             self.assertLogs(level=logging.INFO),
             mock_rx_thread(
-                self.consumer,
+                consumer,
                 lambda: self.producer.send(0x2001, 0x02, b'\x01\x02\x03\x04\x05'),
             ),
         ):
-            self.consumer.wait(0x2001, timeout=TIMEOUT)
-        self.assertEqual(len(self.consumer.active), 1)
+            consumer.wait(0x2001, timeout=TIMEOUT)
+        self.assertEqual(len(consumer.active), 1)
         with (
             self.assertLogs(level=logging.INFO),
-            mock_rx_thread(self.consumer, self.producer.reset),
+            mock_rx_thread(consumer, self.producer.reset),
         ):
-            self.assertIsNotNone(self.consumer.wait(timeout=TIMEOUT))
-        self.assertEqual(len(self.consumer.active), 0)
-        self.assertEqual(len(self.consumer.log), 2)
+            self.assertIsNotNone(consumer.wait(timeout=TIMEOUT))
+        self.assertEqual(len(consumer.active), 0)
+        self.assertEqual(len(consumer.log), 2)
 
 
 if __name__ == "__main__":

--- a/test/test_emcy.py
+++ b/test/test_emcy.py
@@ -6,7 +6,6 @@ from contextlib import contextmanager
 import can
 
 import canopen
-import canopen.emcy
 
 
 TIMEOUT = 0.1
@@ -238,7 +237,6 @@ class TestEmcyError(unittest.TestCase):
         check(0xf100, "")
         check(0xff00, "Device Specific")
         check(0xffff, "Device Specific")
-
 
 
 class TestEmcyProducer(unittest.TestCase):

--- a/test/test_emcy.py
+++ b/test/test_emcy.py
@@ -13,6 +13,7 @@ TIMEOUT = 0.1
 
 
 class TestEmcy(unittest.TestCase):
+
     def setUp(self):
         self.emcy = canopen.emcy.EmcyConsumer()
 
@@ -181,6 +182,7 @@ class TestEmcy(unittest.TestCase):
 
 
 class TestEmcyError(unittest.TestCase):
+
     def test_emcy_error(self):
         error = EmcyError(0x2001, 0x02, b'\x00\x01\x02\x03\x04', 1000)
         self.assertEqual(error.code, 0x2001)
@@ -258,6 +260,7 @@ class TestEmcyError(unittest.TestCase):
 
 
 class TestEmcyProducer(unittest.TestCase):
+
     def setUp(self):
         self.txbus = can.Bus(interface="virtual")
         self.rxbus = can.Bus(interface="virtual")


### PR DESCRIPTION
## What type of PR is this?

/kind bugfix test
/area emcy.py

---

## What this PR does / why we need it

This PR incorporates the review feedback from #604 (by @yuvraj-kolkar17) as suggested by @acolomb, since the original contributor has been unresponsive for several months.

**Bug fix in `canopen/emcy.py`:**
An exception raised in one EMCY callback would silently abort all subsequent callbacks in the list. The `on_emcy()` loop now wraps each callback in `try/except` and logs the exception, so remaining callbacks are always called.

**Test improvements in `test/test_emcy.py`:**
- Convert leading comment to docstring in `test_emcy_consumer_on_emcy`
- Remove superfluous inline `# Dispatch …` comments
- `test_emcy_consumer_initialization`: verify initial state (without testing `threading.Condition` type as an implementation detail)
- `test_emcy_consumer_multiple_callbacks`: simplified using lambdas
- `test_emcy_consumer_callback_exception_handling`: rewritten with lambdas; adds assertion `assertEqual(['success1', 'success2'])` that verifies the fix
- `test_emcy_consumer_error_reset_variants`: various reset code patterns
- `test_emcy_consumer_wait_timeout_edge_cases`: zero/near-zero timeouts
- `test_emcy_consumer_wait_concurrent_errors`: multiple concurrent errors
- `TestEmcyIntegration`: producer-consumer roundtrip tests using `network.subscribe()` instead of manual `rxbus.recv()` calls
- Removed tests that only exercised internal implementation details or Python's own exception mechanism

---

## Which issue(s) this PR fixes

Closes #604

---

## Does this PR introduce a user-facing change?

```text
NONE
```