### PR TITLE
Add some basic rules for ruff linter and black formatting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,10 @@ exclude = [
 
 [tool.ruff]
 line-length = 96
+[tool.ruff.lint.isort]
+case-sensitive = true
+order-by-type = false
+lines-after-imports = 2
 
 [tool.black]
 line-length = 96

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,3 +56,10 @@ exclude = [
     "^test*",
     "^setup.py*",
 ]
+
+[tool.ruff]
+line-length = 96
+
+[tool.black]
+line-length = 96
+skip-string-normalization = true


### PR DESCRIPTION
Line-length 96 is a compomise because 80 is problematic with existing
code, but we want a bit of headroom for the next common limit of 100.

String "normalization" is complete noise in most cases, that could be
enabled again after some general cleanup.

Make sure that ruff agrees with the previously used import ordering
style from isort.

The last change is extracted from #644.