### PR TITLE
Clarify ODVariable.data_type cannot be None

### DIFF
--- a/canopen/objectdictionary/__init__.py
+++ b/canopen/objectdictionary/__init__.py
@@ -366,7 +366,7 @@ class ODVariable:
         #: The value of this variable stored in the object dictionary
         self.value: Optional[int] = None
         #: Data type according to the standard as an :class:`int`
-        self.data_type: Optional[int] = None
+        self.data_type: int = 0
         #: Access type, should be "rw", "ro", "wo", or "const"
         self.access_type: str = "rw"
         #: The variable represents a DOMAIN ObjectType
@@ -480,7 +480,7 @@ class ODVariable:
                 return self.STRUCT_TYPES[self.data_type].pack(value)
             except struct.error:
                 raise ValueError("Value does not fit in specified type")
-        elif self.data_type is None:
+        elif not self.data_type:
             raise ObjectDictionaryError("Data type has not been specified")
         else:
             raise TypeError(

--- a/canopen/objectdictionary/eds.py
+++ b/canopen/objectdictionary/eds.py
@@ -4,7 +4,7 @@ import copy
 import logging
 import re
 from configparser import NoOptionError, NoSectionError, RawConfigParser
-from typing import TYPE_CHECKING
+from typing import Any, TYPE_CHECKING
 
 from canopen.objectdictionary import (
     ODArray,
@@ -204,7 +204,7 @@ def import_from_node(node_id: int, network: canopen.network.Network):
     return od
 
 
-def _calc_bit_length(data_type):
+def _calc_bit_length(data_type: int) -> int:
     if data_type == datatypes.INTEGER8:
         return 8
     elif data_type == datatypes.INTEGER16:
@@ -215,7 +215,7 @@ def _calc_bit_length(data_type):
         return 64
     else:
         raise ValueError(
-            f"Invalid data_type '{data_type}', expecting a signed integer data_type."
+            f"Invalid data_type 0x{data_type:04X}, expecting an integer data_type."
         )
 
 
@@ -229,7 +229,7 @@ def _signed_int_from_hex(hex_str, bit_length):
         return number
 
 
-def _convert_variable(node_id, var_type, value):
+def _convert_variable(node_id: int, var_type: int, value: Any) -> Any:
     if var_type in (datatypes.OCTET_STRING, datatypes.DOMAIN):
         return bytes.fromhex(value)
     elif var_type in (datatypes.VISIBLE_STRING, datatypes.UNICODE_STRING):
@@ -245,7 +245,7 @@ def _convert_variable(node_id, var_type, value):
             return int(value, 0)
 
 
-def _revert_variable(var_type, value):
+def _revert_variable(var_type: int, value: Any) -> Any:
     if value is None:
         return None
     if var_type in (datatypes.OCTET_STRING, datatypes.DOMAIN):

--- a/test/test_od.py
+++ b/test/test_od.py
@@ -171,10 +171,13 @@ class TestDataConversions(unittest.TestCase):
         self.assertEqual(var.decode_raw(b"zero terminated\x00"), b"zero terminated\x00")
         self.assertEqual(var.encode_raw(b"testing"), b"testing")
 
-    def test_unset_data_type(self):
-        var = od.ODVariable("Test unset", 0x1000)
+    def test_unknown_data_type(self):
+        var = od.ODVariable("Test unknown", 0x1000)
         # data_type intentionally left at default (unset)
         with self.assertRaises(od.ObjectDictionaryError):
+            var.encode_raw(42)
+        var.data_type = 0x7F  # from Device profile specific Standard Data types
+        with self.assertRaises(TypeError):
             var.encode_raw(42)
 
 

--- a/test/test_od.py
+++ b/test/test_od.py
@@ -171,6 +171,12 @@ class TestDataConversions(unittest.TestCase):
         self.assertEqual(var.decode_raw(b"zero terminated\x00"), b"zero terminated\x00")
         self.assertEqual(var.encode_raw(b"testing"), b"testing")
 
+    def test_unset_data_type(self):
+        var = od.ODVariable("Test unset", 0x1000)
+        # data_type intentionally left at default (unset)
+        with self.assertRaises(od.ObjectDictionaryError):
+            var.encode_raw(42)
+
 
 class TestAlternativeRepresentations(unittest.TestCase):
 


### PR DESCRIPTION
Use a simple integer zero as dummy value for "unset" in instances. This fixes some type checker errors.  Add type hints for functions involving those values.