### PR TITLE
od: Robust path handling without type errors

### DIFF
--- a/canopen/objectdictionary/__init__.py
+++ b/canopen/objectdictionary/__init__.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import logging
 import os
 import struct
+import sys
 from collections.abc import Collection, Iterator, Mapping, MutableMapping
 from typing import Optional, TextIO, Union
 
@@ -50,7 +51,9 @@ def export_od(
 
     opened_here: Optional[TextIO] = None
     try:
-        if isinstance(dest, (str, os.PathLike)):
+        if dest is None:
+            dest = sys.stdout
+        elif isinstance(dest, (str, os.PathLike)):
             if doc_type is None:
                 _, suffix = os.path.splitext(os.fspath(dest).lower())
                 for t in supported_doctypes:

--- a/canopen/objectdictionary/__init__.py
+++ b/canopen/objectdictionary/__init__.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 def export_od(
     od: ObjectDictionary,
     dest: Union[str, TextIO, None] = None,
-    doc_type: Optional[str] = None
+    doc_type: Optional[str] = None,
 ) -> None:
     """Export an object dictionary.
 
@@ -47,7 +47,7 @@ def export_od(
             f"supported formats: {supported}"
         )
 
-    opened_here = False
+    opened_here: Optional[TextIO] = None
     try:
         if isinstance(dest, str):
             if doc_type is None:
@@ -58,7 +58,7 @@ def export_od(
                 else:
                     doc_type = "eds"
             dest = open(dest, 'w')
-            opened_here = True
+            opened_here = dest
 
         if doc_type == "eds":
             from canopen.objectdictionary import eds
@@ -68,8 +68,8 @@ def export_od(
             return eds.export_dcf(od, dest)
     finally:
         # If dest is opened in this fn, it should be closed
-        if opened_here:
-            dest.close()
+        if opened_here is not None:
+            opened_here.close()
 
 
 def import_od(

--- a/canopen/objectdictionary/__init__.py
+++ b/canopen/objectdictionary/__init__.py
@@ -69,7 +69,7 @@ def export_od(
             from canopen.objectdictionary import eds
             return eds.export_dcf(od, dest)
     finally:
-        # If dest is opened in this fn, it should be closed
+        # If dest is opened in this function, it should be closed
         if opened_here is not None:
             opened_here.close()
 

--- a/canopen/objectdictionary/__init__.py
+++ b/canopen/objectdictionary/__init__.py
@@ -5,6 +5,7 @@ Object Dictionary module
 from __future__ import annotations
 
 import logging
+import os
 import struct
 from collections.abc import Collection, Iterator, Mapping, MutableMapping
 from typing import Optional, TextIO, Union
@@ -19,7 +20,7 @@ logger = logging.getLogger(__name__)
 
 def export_od(
     od: ObjectDictionary,
-    dest: Union[str, TextIO, None] = None,
+    dest: Union[str, os.PathLike, TextIO, None] = None,
     doc_type: Optional[str] = None,
 ) -> None:
     """Export an object dictionary.
@@ -49,10 +50,11 @@ def export_od(
 
     opened_here: Optional[TextIO] = None
     try:
-        if isinstance(dest, str):
+        if isinstance(dest, (str, os.PathLike)):
             if doc_type is None:
+                _, suffix = os.path.splitext(os.fspath(dest).lower())
                 for t in supported_doctypes:
-                    if dest.endswith(f".{t}"):
+                    if suffix == f".{t}":
                         doc_type = t
                         break
                 else:

--- a/canopen/objectdictionary/__init__.py
+++ b/canopen/objectdictionary/__init__.py
@@ -75,7 +75,7 @@ def export_od(
 
 
 def import_od(
-    source: Union[str, TextIO, None],
+    source: Union[str, os.PathLike, TextIO, None],
     node_id: Optional[int] = None,
 ) -> ObjectDictionary:
     """Parse an EDS, DCF, or EPF file.
@@ -92,16 +92,17 @@ def import_od(
     """
     if source is None:
         return ObjectDictionary()
-    if hasattr(source, "read"):
+    filename = ""
+    if isinstance(source, (str, os.PathLike)):
+        # Path to file
+        filename = os.fspath(source)
+    elif hasattr(source, "read"):
         # File like object
-        filename = source.name
+        filename = getattr(source, "name", "")
     elif hasattr(source, "tag"):
         # XML tree, probably from an EPF file
         filename = "od.epf"
-    else:
-        # Path to file
-        filename = source
-    suffix = filename[filename.rfind("."):].lower()
+    _, suffix = os.path.splitext(filename.lower())
     if suffix in (".eds", ".dcf"):
         from canopen.objectdictionary import eds
         return eds.import_eds(source, node_id)

--- a/canopen/objectdictionary/eds.py
+++ b/canopen/objectdictionary/eds.py
@@ -4,7 +4,7 @@ import copy
 import logging
 import re
 from configparser import NoOptionError, NoSectionError, RawConfigParser
-from typing import Any, TYPE_CHECKING
+from typing import Any, TextIO, TYPE_CHECKING
 
 from canopen.objectdictionary import (
     ODArray,
@@ -362,11 +362,11 @@ def copy_variable(eds, section, subindex, src_var):
     return var
 
 
-def export_dcf(od, dest=None, fileInfo={}):
+def export_dcf(od: ObjectDictionary, dest: TextIO, fileInfo={}):
     return export_eds(od, dest, fileInfo, True)
 
 
-def export_eds(od, dest=None, file_info={}, device_commisioning=False):
+def export_eds(od: ObjectDictionary, dest: TextIO, file_info={}, device_commisioning=False):
     def export_object(obj, eds):
         if isinstance(obj, ODVariable):
             return export_variable(obj, eds)
@@ -542,9 +542,5 @@ def export_eds(od, dest=None, file_info={}, device_commisioning=False):
     add_list("MandatoryObjects", supported_mantatory_indices)
     add_list("OptionalObjects", supported_optional_indices)
     add_list("ManufacturerObjects", supported_manufacturer_indices)
-
-    if not dest:
-        import sys
-        dest = sys.stdout
 
     eds.write(dest, False)

--- a/test/test_eds.py
+++ b/test/test_eds.py
@@ -67,8 +67,6 @@ class TestEDS(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "''"):
             canopen.import_od('')
         with self.assertRaisesRegex(ValueError, "''"):
-            canopen.import_od(object())
-        with self.assertRaisesRegex(ValueError, "''"):
             filelike_object = io.StringIO()  # no .name attribute
             self.addCleanup(filelike_object.close)
             canopen.import_od(filelike_object)
@@ -76,6 +74,10 @@ class TestEDS(unittest.TestCase):
     def test_load_file_object(self):
         with open(SAMPLE_EDS) as fp:
             od = canopen.import_od(fp)
+        self.assertTrue(len(od) > 0)
+
+    def test_load_pathlib_path(self):
+        od = canopen.import_od(pathlib.Path(SAMPLE_EDS))
         self.assertTrue(len(od) > 0)
 
     def test_load_implicit_nodeid(self):

--- a/test/test_eds.py
+++ b/test/test_eds.py
@@ -1,3 +1,4 @@
+import contextlib
 import io
 import os
 import pathlib
@@ -337,7 +338,6 @@ class TestEDS(unittest.TestCase):
 
     def test_roundtrip_custom_options(self):
         """custom_options survive an EDS export/import round-trip."""
-        import io
         with io.StringIO() as dest:
             canopen.export_od(self.od, dest, 'eds')
             dest.name = 'mock.eds'
@@ -348,7 +348,6 @@ class TestEDS(unittest.TestCase):
 
     def test_roundtrip_custom_options_not_duplicated_as_standard(self):
         """After round-trip the re-imported object must not contain standard keys."""
-        import io
         with io.StringIO() as dest:
             canopen.export_od(self.od, dest, 'eds')
             dest.name = 'mock.eds'
@@ -449,7 +448,6 @@ class TestEDS(unittest.TestCase):
                     self.verify_od(dest, doctype)
 
     def test_export_eds_to_stdout(self):
-        import contextlib
         with contextlib.redirect_stdout(io.StringIO()) as f:
             ret = canopen.export_od(self.od, None, "eds")
         self.assertIsNone(ret)

--- a/test/test_eds.py
+++ b/test/test_eds.py
@@ -2,6 +2,7 @@ import io
 import os
 import pathlib
 import unittest
+from unittest.mock import mock_open, patch
 
 import canopen
 from canopen.objectdictionary.eds import _signed_int_from_hex
@@ -297,6 +298,31 @@ class TestEDS(unittest.TestCase):
                         buf.name = "mock.eds"
                         self.verify_od(buf, "eds")
 
+    def test_export_eds_auto_close(self):
+        m_open = mock_open()
+        with patch("canopen.objectdictionary.open", m_open):
+            canopen.export_od(self.od, m_open)
+        fd = m_open()
+        # File object already passed in must NOT be closed
+        fd.close.assert_not_called()
+        for path in ("mock.eds", pathlib.Path("mock.eds")):
+            with self.subTest(path=path):
+                m_open = mock_open()
+                with patch("canopen.objectdictionary.open", m_open):
+                    canopen.export_od(self.od, path)
+                fd = m_open()
+                # File object opened at path must be closed before return
+                fd.close.assert_called_once()
+
+    def test_export_eds_auto_close_exception(self):
+        m_open = mock_open()
+        fd = m_open()
+        fd.write.side_effect = IOError("Simulated write failure")
+        with patch("canopen.objectdictionary.open", m_open), self.assertRaises(IOError):
+            canopen.export_od(self.od, "mock.eds")
+            # File object opened at path must be closed on inner exception
+            fd.close.assert_called_once()
+
     def test_export_eds_unknown_doctype(self):
         filelike_object = io.StringIO()
         self.addCleanup(filelike_object.close)
@@ -333,7 +359,6 @@ class TestEDS(unittest.TestCase):
             # 'name' member.
             buf.name = "mock.eds"
             self.verify_od(buf, "eds")
-
 
     def verify_od(self, source, doctype):
         exported_od = canopen.import_od(source)

--- a/test/test_eds.py
+++ b/test/test_eds.py
@@ -2,7 +2,7 @@ import io
 import os
 import pathlib
 import unittest
-from unittest.mock import mock_open, patch
+from unittest.mock import MagicMock, patch
 
 import canopen
 from canopen.objectdictionary.eds import _signed_int_from_hex
@@ -301,29 +301,31 @@ class TestEDS(unittest.TestCase):
                         self.verify_od(buf, "eds")
 
     def test_export_eds_auto_close(self):
-        m_open = mock_open()
-        with patch("canopen.objectdictionary.open", m_open):
-            canopen.export_od(self.od, m_open)
-        fd = m_open()
+        fd = io.StringIO()
+        self.addCleanup(fd.close)
+        canopen.export_od(self.od, fd)
         # File object already passed in must NOT be closed
-        fd.close.assert_not_called()
+        self.assertIs(fd.closed, False)
         for path in ("mock.eds", pathlib.Path("mock.eds")):
             with self.subTest(path=path):
-                m_open = mock_open()
-                with patch("canopen.objectdictionary.open", m_open):
+                fd = io.StringIO()
+                with patch("canopen.objectdictionary.open", return_value=fd):
                     canopen.export_od(self.od, path)
-                fd = m_open()
                 # File object opened at path must be closed before return
-                fd.close.assert_called_once()
+                self.assertIs(fd.closed, True)
 
     def test_export_eds_auto_close_exception(self):
-        m_open = mock_open()
-        fd = m_open()
+        buf = io.StringIO()
+        self.addCleanup(buf.close)
+        fd = MagicMock(wraps=buf)
         fd.write.side_effect = IOError("Simulated write failure")
-        with patch("canopen.objectdictionary.open", m_open), self.assertRaises(IOError):
+        with (
+            patch("canopen.objectdictionary.open", return_value=fd),
+            self.assertRaises(IOError),
+        ):
             canopen.export_od(self.od, "mock.eds")
-            # File object opened at path must be closed on inner exception
-            fd.close.assert_called_once()
+        # File object opened at path must be closed on inner exception
+        self.assertIs(buf.closed, True)
 
     def test_export_eds_unknown_doctype(self):
         filelike_object = io.StringIO()

--- a/test/test_eds.py
+++ b/test/test_eds.py
@@ -1,4 +1,6 @@
+import io
 import os
+import pathlib
 import unittest
 
 import canopen
@@ -54,10 +56,18 @@ class TestEDS(unittest.TestCase):
     def test_load_nonexisting_file(self):
         with self.assertRaises(IOError):
             canopen.import_od('/path/to/wrong_file.eds')
+        with self.assertRaises(IOError):
+            canopen.import_od(pathlib.Path('/path/to/wrong_file.eds'))
 
     def test_load_unsupported_format(self):
         with self.assertRaisesRegex(ValueError, "'py'"):
             canopen.import_od(__file__)
+        with self.assertRaisesRegex(ValueError, "''"):
+            canopen.import_od('')
+        with self.assertRaisesRegex(ValueError, "''"):
+            filelike_object = io.StringIO()  # no .name attribute
+            self.addCleanup(filelike_object.close)
+            canopen.import_od(filelike_object)
 
     def test_load_file_object(self):
         with open(SAMPLE_EDS) as fp:
@@ -70,8 +80,6 @@ class TestEDS(unittest.TestCase):
         self.assertEqual(od.node_id, 16)
 
     def test_load_implicit_nodeid_fallback(self):
-        import io
-
         # First, remove the NodeID option from DeviceComissioning.
         with open(SAMPLE_EDS) as f:
             lines = [L for L in f.readlines() if not L.startswith("NodeID=")]
@@ -93,8 +101,6 @@ class TestEDS(unittest.TestCase):
         self.assertEqual(od.bitrate, 500_000)
 
     def test_load_baudrate_fallback(self):
-        import io
-
         # Remove the Baudrate option.
         with open(SAMPLE_EDS) as f:
             lines = [L for L in f.readlines() if not L.startswith("Baudrate=")]
@@ -240,7 +246,6 @@ class TestEDS(unittest.TestCase):
 
     def test_roundtrip_domain_objects(self):
         # ObjectType==DOMAIN survive an EDS export/import round-trip
-        import io
         with io.StringIO() as dest:
             canopen.export_od(self.od, dest, 'eds')
             dest.name = 'mock.eds'
@@ -271,7 +276,6 @@ class TestEDS(unittest.TestCase):
                         self.verify_od(dest, doctype)
 
     def test_export_eds_to_file_unknown_extension(self):
-        import io
         for suffix in ".txt", "":
             with tmp_file(suffix=suffix) as tmp:
                 dest = tmp.name
@@ -294,7 +298,6 @@ class TestEDS(unittest.TestCase):
                         self.verify_od(buf, "eds")
 
     def test_export_eds_unknown_doctype(self):
-        import io
         filelike_object = io.StringIO()
         self.addCleanup(filelike_object.close)
         for dest in "filename", None, filelike_object:
@@ -307,7 +310,6 @@ class TestEDS(unittest.TestCase):
                         os.stat(dest)
 
     def test_export_eds_to_filelike_object(self):
-        import io
         for doctype in "eds", "dcf":
             with io.StringIO() as dest:
                 with self.subTest(dest=dest, doctype=doctype):
@@ -321,7 +323,6 @@ class TestEDS(unittest.TestCase):
 
     def test_export_eds_to_stdout(self):
         import contextlib
-        import io
         with contextlib.redirect_stdout(io.StringIO()) as f:
             ret = canopen.export_od(self.od, None, "eds")
         self.assertIsNone(ret)

--- a/test/test_eds.py
+++ b/test/test_eds.py
@@ -66,6 +66,8 @@ class TestEDS(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "''"):
             canopen.import_od('')
         with self.assertRaisesRegex(ValueError, "''"):
+            canopen.import_od(object())
+        with self.assertRaisesRegex(ValueError, "''"):
             filelike_object = io.StringIO()  # no .name attribute
             self.addCleanup(filelike_object.close)
             canopen.import_od(filelike_object)


### PR DESCRIPTION
Fix the union-attr errors squelched in #651 properly.  In the process, extend `import_od()` to gracefully handle some edge cases around missing file names and non-`str` paths in the `source` argument.

Extend unit tests around import and export functions.  Note that these are still a bit convoluted because the EDS import is tested through the generic, format-agnostic OD API.  This is still much easier than splitting tests between generic and format-specific though.  If ever someone adds unit tests covering the EPF import, that might need some refactoring.