### PR TITLE
nmt: Fix NmtSlave on a node without a heartbeat producer time

### DIFF
--- a/canopen/nmt.py
+++ b/canopen/nmt.py
@@ -230,8 +230,11 @@ class NmtSlave(NmtBase):
         # The heartbeat service should start on the transition
         # between INITIALIZING and PRE-OPERATIONAL state
         if old_state == 0 and self._state == 127:
-            heartbeat_time_ms = self._local_node.sdo[0x1017].raw
-            self.start_heartbeat(heartbeat_time_ms)
+            try:
+                heartbeat_time_ms = self._local_node.sdo[0x1017].raw
+                self.start_heartbeat(heartbeat_time_ms)
+            except KeyError:
+                pass
         else:
             self.update_heartbeat()
 

--- a/test/test_nmt.py
+++ b/test/test_nmt.py
@@ -193,6 +193,14 @@ class TestNmtSlave(unittest.TestCase):
 
         self.local_node.nmt.stop_heartbeat()
 
+    def test_heartbeat_no_producer_time(self):
+        # Create a node without the producer heartbeat time parameter
+        node = canopen.LocalNode(1, canopen.ObjectDictionary())
+        with self.assertRaises(KeyError):
+            node.sdo[0x1017].raw = 100
+        # Should not fail because of missing 0x1017 object entry
+        node.nmt.state = "PRE-OPERATIONAL"
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
The NMT state transition from INITIALISING to PRE-OPERATIONAL causes the heartbeat to start automatically if the parameter is non-zero in object 0x1017:00.  This check however raises an exception if the object does not even exist.

Cover this state in tests and explicitly ignore a KeyError when asking for the object.