### PR TITLE
od: Extend physical conversion to integer factors, fix typing

### DIFF
--- a/canopen/objectdictionary/__init__.py
+++ b/canopen/objectdictionary/__init__.py
@@ -354,7 +354,7 @@ class ODVariable:
         #: Physical unit
         self.unit: str = ""
         #: Factor between physical unit and integer value
-        self.factor: float = 1
+        self.factor: Union[int, float] = 1
         #: Minimum allowed value
         self.min: Optional[int] = None
         #: Maximum allowed value

--- a/canopen/objectdictionary/__init__.py
+++ b/canopen/objectdictionary/__init__.py
@@ -489,7 +489,7 @@ class ODVariable:
     def decode_phys(
         self, value: Union[int, bool, float, str, bytes]
     ) -> Union[int, bool, float, str, bytes]:
-        if self.data_type in INTEGER_TYPES:
+        if self.data_type in NUMBER_TYPES:
             assert isinstance(value, (int, float))
             value *= self.factor
         return value
@@ -497,10 +497,12 @@ class ODVariable:
     def encode_phys(
         self, value: Union[int, bool, float, str, bytes]
     ) -> Union[int, bool, float, str, bytes]:
-        if self.data_type in INTEGER_TYPES:
+        if self.data_type in NUMBER_TYPES:
             assert isinstance(value, (int, float))
             if self.factor != 1:
-                value = round(value / self.factor)
+                value = value / self.factor
+            if self.data_type in INTEGER_TYPES:
+                value = round(value)
         return value
 
     def decode_desc(self, value: int) -> str:

--- a/canopen/objectdictionary/__init__.py
+++ b/canopen/objectdictionary/__init__.py
@@ -486,13 +486,19 @@ class ODVariable:
             raise TypeError(
                 f"Do not know how to encode {value!r} to data type 0x{self.data_type:X}")
 
-    def decode_phys(self, value: int) -> Union[int, bool, float, str, bytes]:
+    def decode_phys(
+        self, value: Union[int, bool, float, str, bytes]
+    ) -> Union[int, bool, float, str, bytes]:
         if self.data_type in INTEGER_TYPES:
+            assert isinstance(value, (int, float))
             value *= self.factor
         return value
 
-    def encode_phys(self, value: Union[int, bool, float, str, bytes]) -> int:
+    def encode_phys(
+        self, value: Union[int, bool, float, str, bytes]
+    ) -> Union[int, bool, float, str, bytes]:
         if self.data_type in INTEGER_TYPES:
+            assert isinstance(value, (int, float))
             if self.factor != 1:
                 value = round(value / self.factor)
         return value

--- a/canopen/objectdictionary/__init__.py
+++ b/canopen/objectdictionary/__init__.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import logging
 import struct
 from collections.abc import Collection, Iterator, Mapping, MutableMapping
-from typing import Optional, TextIO, Union
+from typing import Optional, TextIO, Union, cast
 
 from canopen.objectdictionary.datatypes import *
 from canopen.objectdictionary.datatypes import IntegerN, UnsignedN
@@ -490,19 +490,20 @@ class ODVariable:
         self, value: Union[int, bool, float, str, bytes]
     ) -> Union[int, bool, float, str, bytes]:
         if self.data_type in NUMBER_TYPES:
-            assert isinstance(value, (int, float))
-            value *= self.factor
+            numeric = cast(Union[int, float], value)
+            value = numeric * self.factor
         return value
 
     def encode_phys(
         self, value: Union[int, bool, float, str, bytes]
     ) -> Union[int, bool, float, str, bytes]:
         if self.data_type in NUMBER_TYPES:
-            assert isinstance(value, (int, float))
+            numeric = cast(Union[int, float], value)
             if self.factor != 1:
-                value = value / self.factor
+                numeric = numeric / self.factor
             if self.data_type in INTEGER_TYPES:
-                value = round(value)
+                numeric = round(numeric)
+            value = numeric
         return value
 
     def decode_desc(self, value: int) -> str:

--- a/canopen/objectdictionary/eds.py
+++ b/canopen/objectdictionary/eds.py
@@ -337,9 +337,12 @@ def build_variable(
     # they are implemented in the python canopen package, so we can at least try to use them
     if eds.has_option(section, "Factor"):
         try:
-            var.factor = float(eds.get(section, "Factor"))
+            var.factor = int(eds.get(section, "Factor"))
         except ValueError:
-            pass
+            try:
+                var.factor = float(eds.get(section, "Factor"))
+            except ValueError:
+                pass
     if eds.has_option(section, "Description"):
         try:
             var.description = eds.get(section, "Description")

--- a/canopen/objectdictionary/eds.py
+++ b/canopen/objectdictionary/eds.py
@@ -342,7 +342,10 @@ def build_variable(
             try:
                 var.factor = float(eds.get(section, "Factor"))
             except ValueError:
-                pass
+                logger.warning(
+                    "Could not parse Factor for %s in section [%s], ignoring",
+                    var.name, section,
+                )
     if eds.has_option(section, "Description"):
         try:
             var.description = eds.get(section, "Description")

--- a/test/sample.eds
+++ b/test/sample.eds
@@ -995,7 +995,7 @@ ParameterName=Highest subindex
 ObjectType=0x7
 DataType=0x0005
 AccessType=ro
-DefaultValue=0x02
+DefaultValue=0x03
 PDOMapping=0x0
 
 [3050sub1]
@@ -1017,6 +1017,16 @@ PDOMapping=0x0
 Factor=ERROR
 Description=
 Unit=
+
+[3050sub3]
+ParameterName=Integer Factor
+ObjectType=0x7
+DataType=0x0004
+AccessType=ro
+PDOMapping=0x0
+Factor=42
+Description=Should be parsed as integer
+Unit=answer
 
 [3063]
 ParameterName=DOMAIN object

--- a/test/test_eds.py
+++ b/test/test_eds.py
@@ -211,11 +211,14 @@ class TestEDS(unittest.TestCase):
         var = self.od['EDS file extensions']['FactorAndDescription']
         self.assertEqual(var.factor, 0.1)
         self.assertEqual(var.description, "This is the a test description")
-        self.assertEqual(var.unit,'mV')
+        self.assertEqual(var.unit, 'mV')
         var2 = self.od['EDS file extensions']['Error Factor and No Description']
         self.assertEqual(var2.description, '')
         self.assertEqual(var2.factor, 1)
         self.assertEqual(var2.unit, '')
+        var3 = self.od['EDS file extensions']['Integer Factor']
+        self.assertEqual(var3.factor, 42)
+        self.assertIsInstance(var3.factor, int)
 
     def test_read_domain_object(self):
         var = self.od[0x3063]

--- a/test/test_od.py
+++ b/test/test_od.py
@@ -183,13 +183,32 @@ class TestDataConversions(unittest.TestCase):
 
 class TestAlternativeRepresentations(unittest.TestCase):
 
-    def test_phys(self):
+    def test_phys_integer(self):
         var = od.ODVariable("Test INTEGER16", 0x1000)
         var.data_type = od.INTEGER16
         var.factor = 0.1
-
         self.assertAlmostEqual(var.decode_phys(128), 12.8)
         self.assertEqual(var.encode_phys(-0.1), -1)
+
+    def test_phys_real(self):
+        var = od.ODVariable("Test REAL32", 0x1000)
+        var.data_type = od.REAL32
+        var.factor = 0.1
+        self.assertAlmostEqual(var.decode_phys(128), 12.8)
+        self.assertEqual(var.encode_phys(-0.1), -1)
+
+    def test_phys_boolean(self):
+        var = od.ODVariable("Test BOOLEAN", 0x1000)
+        var.data_type = od.BOOLEAN
+        self.assertEqual(var.decode_phys(True), True)
+        self.assertEqual(var.decode_phys(False), False)
+        self.assertEqual(var.encode_phys(True), True)
+
+    def test_phys_string(self):
+        var = od.ODVariable("Test VISIBLE_STRING", 0x1000)
+        var.data_type = od.VISIBLE_STRING
+        self.assertEqual(var.decode_phys('foo'), 'foo')
+        self.assertEqual(var.encode_phys('bar'), 'bar')
 
     def test_phys_factor_1_int64_roundtrip(self):
         """int64 values must survive encode_phys when factor is 1."""

--- a/test/test_od.py
+++ b/test/test_od.py
@@ -227,6 +227,25 @@ class TestAlternativeRepresentations(unittest.TestCase):
         var.factor = 1.0
         self.assertIsInstance(var.decode_phys(42), float)
 
+    def test_phys_int_factor(self):
+        """Integer factor uses float division + round."""
+        var = od.ODVariable("Test INTEGER16", 0x1000)
+        var.data_type = od.INTEGER16
+        var.factor = 3
+        # 10 / 3 = 3
+        encoded = var.encode_phys(10)
+        self.assertEqual(encoded, 3)
+        self.assertIsInstance(encoded, int)
+
+    def test_phys_int_factor_decodes_to_int(self):
+        """decode_phys with float factor ensures a float result."""
+        var = od.ODVariable("Test INTEGER32", 0x1000)
+        var.data_type = od.INTEGER32
+        var.factor = 10
+        decoded = var.decode_phys(42)
+        self.assertEqual(decoded, 420)
+        self.assertIsInstance(decoded, int)
+
     def test_desc(self):
         var = od.ODVariable("Test UNSIGNED8", 0x1000)
         var.data_type = od.UNSIGNED8


### PR DESCRIPTION
The `Variable.phys` property docstring mentions "Non integers will be
passed as is."  That is correct, but not reflected in the type hints
for the associated `ODVariable.encode_phys()` / `.decode_phys()`
functions.  Extend the return / argument type to all possible internal
data types, instead of plain `int`.

Try factor conversion on all `NUMBER_TYPES`, where it was previously
limited to `INTEGER_TYPES`.  Only apply rounding in `encode_phys()` if the
variable's data type is actually integer-based.

Allow integer factors in type hint for `ODVariable.factor`.  There is
nothing wrong with using integer factors to yield integers
when decoding.  For encoding, the division may still result in a
`float`, while the rounding behavior is kept unchanged for integer-typed
variables.

Thus, try to parse integer factors as integers from EDS files, not forcing
to a `float`.

Related comment first given here: https://github.com/canopen-python/canopen/pull/651#issuecomment-4386512596