### PR TITLE
async pt 1: Add asyncio framework and improve callback system

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2016 Christian Sandberg
+Copyright (c) 2026 Svein Seldal
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/canopen/emcy.py
+++ b/canopen/emcy.py
@@ -24,6 +24,7 @@ class EmcyConsumer:
         self.active: list[EmcyError] = []
         self.callbacks = []
         self.emcy_received = threading.Condition()
+        self.network: canopen.network.Network = canopen.network._UNINITIALIZED_NETWORK
 
     def on_emcy(self, can_id, data, timestamp):
         code, register, data = EMCY_STRUCT.unpack(data)
@@ -38,11 +39,8 @@ class EmcyConsumer:
             self.log.append(entry)
             self.emcy_received.notify_all()
 
-        for callback in self.callbacks:
-            try:
-                callback(entry)
-            except Exception:
-                logger.exception("Exception in EMCY callback")
+        # Call all registered callbacks
+        self.network.dispatch_callbacks(self.callbacks, entry, ignore_errors=True)
 
     def add_callback(self, callback: Callable[[EmcyError], None]):
         """Get notified on EMCY messages from this node.

--- a/canopen/network.py
+++ b/canopen/network.py
@@ -18,12 +18,13 @@ from canopen.objectdictionary.eds import import_from_node
 from canopen.sync import SyncProducer
 from canopen.timestamp import TimeProducer
 
-# Use backported TaskGroup for Python < 3.11, as asyncio.TaskGroup was added in 3.11
-if sys.version_info < (3, 11):
-    from taskgroup import TaskGroup
-else:
+# Use backported TaskGroup and ExceptionGroup for Python < 3.11
+if sys.version_info >= (3, 11):
+    from builtins import ExceptionGroup
     from asyncio import TaskGroup
-
+else:
+    from taskgroup import TaskGroup
+    from exceptiongroup import ExceptionGroup
 
 logger = logging.getLogger(__name__)
 
@@ -63,6 +64,9 @@ class Network(MutableMapping):
         #: network is closed.
         self.exit_stack: AsyncExitStack = AsyncExitStack()
         self.loop: Optional[asyncio.AbstractEventLoop] = None
+        #: A list of exceptions that have occurred in callbacks. This is used to
+        #: ensure that exceptions are not lost
+        self.exceptions: list[BaseException] = []
         self.sync = SyncProducer(self)
         self.time = TimeProducer(self)
         self.nmt = NmtMaster(0)
@@ -188,38 +192,6 @@ class Network(MutableMapping):
     def is_running_async(self) -> bool:
         """Check if canopen has been connected with async"""
         return self.loop is not None
-
-    def create_task(self, coro: Coroutine, *args, **kwarge) -> asyncio.Task:
-        """Create an async task.
-
-        This function is thread-safe and can be called from any thread. If
-        called from the same thread as the event loop, it will use
-        :code:`asyncio.create_task()` directly. If called from a different
-        thread, it will use :code:`asyncio.run_coroutine_threadsafe()` to
-        schedule the task in the event loop.
-
-        All tasks created with this function is managed by the task group
-        in :attr:`canopen.Network.taskgroup`, which takes care of cleaning up
-        the tasks when the network is closed and handles exceptions in the tasks.
-
-        :param coro:
-            The coroutine to run in the event loop.
-        """
-        if threading.get_ident() == self.thread_id:
-            # If we are running in the same thread as the event loop
-            # asyncio.create_task() can be used directly.
-            return self.taskgroup.create_task(coro, *args, **kwarge)
-
-        else:
-            # Running in a different thread.
-            async def _create_task():
-                return self.taskgroup.create_task(coro, *args, **kwarge)
-            # Since this is another thread asyncio.get_running_loop() will
-            # not work. We need to use the stored event loop.
-            future = asyncio.run_coroutine_threadsafe(_create_task(), self.loop)
-            # The result() will block until the _create_task() coroutine has
-            # been executed and it returns the actual task object.
-            return future.result()
 
     def add_node(
         self,
@@ -355,12 +327,16 @@ class Network(MutableMapping):
             will continue running. If False, exceptions in callbacks will be raised,
             which will stop the program. If None, the value of self.FILTER_ERRORS
         """
-        logger.exception("Exception in callback: %s", exc_info=exc)
+        logger.exception("Exception in callback", exc_info=exc)
 
-        if ignore_errors is None:
-            ignore_errors = self.FILTER_ERRORS
-        if not ignore_errors:
+        ignore = self.FILTER_ERRORS if ignore_errors is None else ignore_errors
+        if not ignore:
             raise exc
+        if not ignore_errors:
+            # This is when ignore_errors is default None, and self.FILTER_ERRORS
+            # must be True. We do not log when the user sets ingore_errors
+            # to True.
+            self.exceptions.append(exc)
 
     def dispatch_callbacks(self, callbacks: list[Callable], *args, **kwargs) -> None:
         """Dispatch a list of callbacks with the given arguments.
@@ -380,9 +356,57 @@ class Network(MutableMapping):
             try:
                 result = callback(*args, **kwargs)
                 if result is not None and asyncio.iscoroutine(result):
-                    self.create_task(result)
+                    if self.loop is None:
+                        raise RuntimeError("Network is not running in async mode")
+
+                    # Wrap the coroutine in this function to ensure the
+                    # exceptions is either logged or raised, depending on the
+                    # value of self.FILTER_ERRORS.
+                    async def _error_handler(coro):
+                        try:
+                            return await coro
+                        except Exception as e:
+                            self.on_error(e, ignore_errors)
+
+                    # Create the task
+                    self.create_task(_error_handler(result))
             except Exception as e:
                 self.on_error(e, ignore_errors)
+
+    def create_task(self, coro: Coroutine, *args, **kwarge) -> asyncio.Task:
+        """Create an async task.
+
+        This function is thread-safe and can be called from any thread. If
+        called from the same thread as the event loop, it will use
+        :code:`asyncio.create_task()` directly. If called from a different
+        thread, it will use :code:`asyncio.run_coroutine_threadsafe()` to
+        schedule the task in the event loop.
+
+        All tasks created with this function is managed by the task group
+        in :attr:`canopen.Network.taskgroup`, which takes care of cleaning up
+        the tasks when the network is closed and handles exceptions in the tasks.
+
+        :param coro:
+            The coroutine to run in the event loop.
+        """
+        if self.loop is None:
+            raise RuntimeError("Network is not running in async mode")
+
+        if threading.get_ident() == self.thread_id:
+            # If we are running in the same thread as the event loop
+            # asyncio.create_task() can be used directly.
+            return self.taskgroup.create_task(coro, *args, **kwarge)
+
+        else:
+            # Running in a different thread.
+            async def _create_task():
+                return self.taskgroup.create_task(coro, *args, **kwarge)
+            # Since this is another thread asyncio.get_running_loop() will
+            # not work. We need to use the stored event loop.
+            future = asyncio.run_coroutine_threadsafe(_create_task(), self.loop)
+            # The result() will block until the _create_task() coroutine has
+            # been executed and it returns the actual task object.
+            return future.result()
 
     def check(self) -> None:
         """Check that no fatal error has occurred in the receiving thread.
@@ -390,11 +414,20 @@ class Network(MutableMapping):
         If an exception caused the thread to terminate, that exception will be
         raised.
         """
-        if self.notifier is not None:
-            exc = self.notifier.exception
-            if exc is not None:
-                logger.error("An error has caused receiving of messages to stop")
-                raise exc
+        # Swap the list of exceptions to make sure the exceptions is not reported again
+        exceptions, self.exceptions = self.exceptions, []
+
+        # Check if the notifier has an exception. This might be the case when
+        # FILTER_ERRORS is False
+        if self.notifier is not None and (exc := self.notifier.exception) is not None:
+            exceptions.append(exc)
+
+        if len(exceptions) == 1:
+            logger.error("An error has caused receiving of messages to stop")
+            raise exceptions[0]
+        if len(exceptions) > 1:
+            logger.error("%s errors have caused receiving of messages to stop", len(exceptions))
+            raise ExceptionGroup("Multiple exceptions have occurred in callbacks", exceptions)
 
     def __getitem__(self, node_id: int) -> Union[RemoteNode, LocalNode]:
         return self.nodes[node_id]

--- a/canopen/network.py
+++ b/canopen/network.py
@@ -23,8 +23,8 @@ if sys.version_info >= (3, 11):
     from builtins import ExceptionGroup
     from asyncio import TaskGroup
 else:
-    from taskgroup import TaskGroup
     from exceptiongroup import ExceptionGroup
+    from taskgroup import TaskGroup
 
 logger = logging.getLogger(__name__)
 

--- a/canopen/network.py
+++ b/canopen/network.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import asyncio
 import logging
 import threading
-from collections.abc import Iterator, MutableMapping
+from collections.abc import Coroutine, Iterator, MutableMapping
+from contextlib import AsyncExitStack
 from typing import Callable, Final, Optional, Union
+import sys
 
 import can
 
@@ -14,6 +17,12 @@ from canopen.objectdictionary import ObjectDictionary
 from canopen.objectdictionary.eds import import_from_node
 from canopen.sync import SyncProducer
 from canopen.timestamp import TimeProducer
+
+# Use backported TaskGroup for Python < 3.11, as asyncio.TaskGroup was added in 3.11
+if sys.version_info < (3, 11):
+    from taskgroup import TaskGroup
+else:
+    from asyncio import TaskGroup
 
 
 logger = logging.getLogger(__name__)
@@ -26,6 +35,7 @@ class Network(MutableMapping):
 
     NOTIFIER_CYCLE: float = 1.0  #: Maximum waiting time for one notifier iteration.
     NOTIFIER_SHUTDOWN_TIMEOUT: float = 5.0  #: Maximum waiting time to stop notifiers.
+    FILTER_ERRORS: bool = True  #: If True, exceptions in callbacks will be logged only
 
     def __init__(self, bus: Optional[can.BusABC] = None):
         """
@@ -44,6 +54,15 @@ class Network(MutableMapping):
         self.nodes: dict[int, Union[RemoteNode, LocalNode]] = {}
         self.subscribers: dict[int, list[Callback]] = {}
         self.send_lock = threading.Lock()
+        #: A task group for managing async tasks. This is used to ensure that
+        #: all tasks are properly cleaned up when the network is closed.
+        self.taskgroup: TaskGroup = TaskGroup()
+        self.thread_id: int = threading.get_ident()
+        #: An async exit stack for managing async context managers. This is used
+        #: to ensure that all context managers are properly cleaned up when the
+        #: network is closed.
+        self.exit_stack: AsyncExitStack = AsyncExitStack()
+        self.loop: Optional[asyncio.AbstractEventLoop] = None
         self.sync = SyncProducer(self)
         self.time = TimeProducer(self)
         self.nmt = NmtMaster(0)
@@ -108,6 +127,13 @@ class Network(MutableMapping):
             self.bus = can.Bus(*args, **kwargs)
         logger.info("Connected to '%s'", self.bus.channel_info)
         if self.notifier is None:
+            # The notifier is started without setting the loop paramter, even
+            # when running in async mode. The notifier changes in sublte ways
+            # when the loop parameter is set. All callbacks via the Listener
+            # interface will be called from the separate rx thread, which is
+            # what canopen is designed for. The async mode of the notifier will
+            # send all callbacks to the event loop thread, which is not
+            # compatible with the blocking locks and queues used in canopen.
             self.notifier = can.Notifier(self.bus, self.listeners, self.NOTIFIER_CYCLE)
         return self
 
@@ -135,6 +161,65 @@ class Network(MutableMapping):
 
     def __exit__(self, type, value, traceback):
         self.disconnect()
+
+    async def __aenter__(self):
+        if self.loop is None:
+            self.loop = asyncio.get_running_loop()
+        else:
+            if self.loop != asyncio.get_running_loop():
+                raise RuntimeError("Network is running in a different event loop")
+        self.thread_id = threading.get_ident()
+        try:
+            # Enter the async context for the taskgroup and leave it last
+            await self.exit_stack.enter_async_context(self.taskgroup)
+            # Cleanup the network
+            self.exit_stack.callback(self.disconnect)
+        except Exception:
+            await self.exit_stack.aclose()
+            raise
+        return self
+
+    async def __aexit__(self, type, value, traceback):
+        # Cleanup by running the context managers in reverse order of entry.
+        # Please see __aenter__ for list of contexts.
+        return await self.exit_stack.__aexit__(type, value, traceback)
+
+    @property
+    def is_running_async(self) -> bool:
+        """Check if canopen has been connected with async"""
+        return self.loop is not None
+
+    def create_task(self, coro: Coroutine, *args, **kwarge) -> asyncio.Task:
+        """Create an async task.
+
+        This function is thread-safe and can be called from any thread. If
+        called from the same thread as the event loop, it will use
+        :code:`asyncio.create_task()` directly. If called from a different
+        thread, it will use :code:`asyncio.run_coroutine_threadsafe()` to
+        schedule the task in the event loop.
+
+        All tasks created with this function is managed by the task group
+        in :attr:`canopen.Network.taskgroup`, which takes care of cleaning up
+        the tasks when the network is closed and handles exceptions in the tasks.
+
+        :param coro:
+            The coroutine to run in the event loop.
+        """
+        if threading.get_ident() == self.thread_id:
+            # If we are running in the same thread as the event loop
+            # asyncio.create_task() can be used directly.
+            return self.taskgroup.create_task(coro, *args, **kwarge)
+
+        else:
+            # Running in a different thread.
+            async def _create_task():
+                return self.taskgroup.create_task(coro, *args, **kwarge)
+            # Since this is another thread asyncio.get_running_loop() will
+            # not work. We need to use the stored event loop.
+            future = asyncio.run_coroutine_threadsafe(_create_task(), self.loop)
+            # The result() will block until the _create_task() coroutine has
+            # been executed and it returns the actual task object.
+            return future.result()
 
     def add_node(
         self,
@@ -247,10 +332,57 @@ class Network(MutableMapping):
             Timestamp of the message, preferably as a Unix timestamp
         """
         if can_id in self.subscribers:
-            callbacks = self.subscribers[can_id]
-            for callback in callbacks:
-                callback(can_id, data, timestamp)
+            self.dispatch_callbacks(self.subscribers[can_id], can_id, data, timestamp)
         self.scanner.on_message_received(can_id)
+
+    def on_error(self, exc: BaseException, ignore_errors: Optional[bool] = None) -> None:
+        """Handle any exception in the callbacks.
+
+        With self.FILTER_ERRORS set to True, exceptions in callbacks will be logged
+        only, and the program will continue running. This is useful for
+        production systems where you want to log errors but not crash the
+        entire application due to a single callback failure.
+
+        With self.FILTER_ERRORS set to False, exceptions in callbacks will be raised,
+        which will stop the program. This is useful for development and debugging,
+        where you want to catch errors early and fix them. This is also
+        important for unit tests, as only logging errors may hide problems.
+
+        :param exc:
+            The exception that was raised.
+        :param ignore_errors:
+            If True, exceptions in callbacks will be logged only, and the program
+            will continue running. If False, exceptions in callbacks will be raised,
+            which will stop the program. If None, the value of self.FILTER_ERRORS
+        """
+        logger.exception("Exception in callback: %s", exc_info=exc)
+
+        if ignore_errors is None:
+            ignore_errors = self.FILTER_ERRORS
+        if not ignore_errors:
+            raise exc
+
+    def dispatch_callbacks(self, callbacks: list[Callable], *args, **kwargs) -> None:
+        """Dispatch a list of callbacks with the given arguments.
+
+        :param callbacks:
+            List of callbacks to call
+        :param args:
+            Arguments to pass to the callbacks
+        :param kwargs:
+            Keyword arguments to pass to the callbacks. The "ignore_errors"
+            keyword argument can be used to override the default error handling
+            behavior for this specific call. See :meth:`canopen.Network.on_error`
+            for details.
+        """
+        ignore_errors = kwargs.pop("ignore_errors", None)
+        for callback in callbacks:
+            try:
+                result = callback(*args, **kwargs)
+                if result is not None and asyncio.iscoroutine(result):
+                    self.create_task(result)
+            except Exception as e:
+                self.on_error(e, ignore_errors)
 
     def check(self) -> None:
         """Check that no fatal error has occurred in the receiving thread.
@@ -374,7 +506,7 @@ class MessageListener(can.Listener):
             self.network.notify(msg.arbitration_id, msg.data, msg.timestamp)
         except Exception as e:
             # Exceptions in any callbaks should not affect CAN processing
-            logger.error(str(e))
+            self.network.on_error(e)
 
     def stop(self) -> None:
         """Override abstract base method to release any resources."""

--- a/canopen/nmt.py
+++ b/canopen/nmt.py
@@ -135,8 +135,8 @@ class NmtMaster(NmtBase):
             self._state_received = new_state
             self.state_update.notify_all()
 
-        for callback in self._callbacks:
-            callback(new_state)
+        # Call all registered callbacks
+        self.network.dispatch_callbacks(self._callbacks, new_state)
 
     def send_command(self, code: int):
         """Send an NMT command code to the node.

--- a/canopen/node/remote.py
+++ b/canopen/node/remote.py
@@ -59,6 +59,7 @@ class RemoteNode(BaseNode):
         self.tpdo.network = network
         self.rpdo.network = network
         self.nmt.network = network
+        self.emcy.network = network
         for sdo in self.sdo_channels:
             network.subscribe(sdo.tx_cobid, sdo.on_response)
         network.subscribe(0x700 + self.id, self.nmt.on_heartbeat)
@@ -79,6 +80,7 @@ class RemoteNode(BaseNode):
         self.tpdo.network = canopen.network._UNINITIALIZED_NETWORK
         self.rpdo.network = canopen.network._UNINITIALIZED_NETWORK
         self.nmt.network = canopen.network._UNINITIALIZED_NETWORK
+        self.emcy.network = canopen.network._UNINITIALIZED_NETWORK
 
     def add_sdo(self, rx_cobid, tx_cobid):
         """Add an additional SDO channel.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
 dependencies = [
     "python-can >= 3.0.0",
     "taskgroup; python_version <= '3.13'",
+    "exceptiongroup; python_version <= '3.10'",
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ authors = [
     {name = "Christian Sandberg", email = "christiansandberg@me.com"},
     {name = "André Colomb", email = "src@andre.colomb.de"},
     {name = "André Filipe Silva", email = "afsilva.work@gmail.com"},
+    {name = "Svein Seldal", email = "sveinse@seldal.com"},
 ]
 description = "CANopen stack implementation"
 readme = "README.rst"
@@ -23,6 +24,7 @@ classifiers = [
 ]
 dependencies = [
     "python-can >= 3.0.0",
+    "taskgroup; python_version <= '3.13'",
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 ]
 dependencies = [
     "python-can >= 3.0.0",
-    "taskgroup; python_version <= '3.13'",
+    "taskgroup; python_version <= '3.10'",
     "exceptiongroup; python_version <= '3.10'",
 ]
 dynamic = ["version"]

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,15 @@
+
+import pytest
+
+import canopen
+
+
+@pytest.fixture(scope="session", autouse=True)
+def enable_network_exceptions():
+    """Fixture to enable exceptions in the reception threads.
+
+    This makes sure exceptions are not swallowed in the reception threads,
+    which is useful for debugging and testing.
+    """
+    canopen.Network.FILTER_ERRORS = False
+    yield

--- a/test/test_emcy.py
+++ b/test/test_emcy.py
@@ -24,6 +24,16 @@ def mock_rx_thread(consumer: canopen.emcy.EmcyConsumer, func):
 
 class TestEmcy(unittest.TestCase):
 
+    def setUp(self):
+        self.net = canopen.Network()
+        self.net.connect(interface="virtual")
+        self.net.NOTIFIER_SHUTDOWN_TIMEOUT = 0.0
+        self.emcy = canopen.emcy.EmcyConsumer()
+        self.emcy.network = self.net
+
+    def tearDown(self):
+        self.net.disconnect()
+
     def check_error(self, err, code, reg, data, ts):
         self.assertIsInstance(err, canopen.emcy.EmcyError)
         self.assertIsInstance(err, Exception)
@@ -34,7 +44,7 @@ class TestEmcy(unittest.TestCase):
 
     def test_emcy_consumer_on_emcy(self):
         """Make sure multiple callbacks receive the same information."""
-        emcy = canopen.emcy.EmcyConsumer()
+        emcy = self.emcy
         acc1 = []
         acc2 = []
         emcy.add_callback(lambda err: acc1.append(err))
@@ -70,7 +80,7 @@ class TestEmcy(unittest.TestCase):
         self.assertEqual(len(emcy.active), 0)
 
     def test_emcy_consumer_reset(self):
-        emcy = canopen.emcy.EmcyConsumer()
+        emcy = self.emcy
         emcy.on_emcy(0x81, b'\x01\x20\x02\x00\x01\x02\x03\x04', 1000)
         emcy.on_emcy(0x81, b'\x10\x90\x01\x04\x03\x02\x01\x00', 2000)
         self.assertEqual(len(emcy.log), 2)
@@ -81,7 +91,7 @@ class TestEmcy(unittest.TestCase):
         self.assertEqual(len(emcy.active), 0)
 
     def test_emcy_consumer_wait(self):
-        emcy = canopen.emcy.EmcyConsumer()
+        emcy = self.emcy
 
         def push_err():
             emcy.on_emcy(0x81, b'\x01\x20\x01\x01\x02\x03\x04\x05', 100)
@@ -122,7 +132,7 @@ class TestEmcy(unittest.TestCase):
 
     def test_emcy_consumer_multiple_callbacks(self):
         """Test adding multiple callbacks and their execution order."""
-        emcy = canopen.emcy.EmcyConsumer()
+        emcy = self.emcy
         call_order = []
         emcy.add_callback(lambda err: call_order.append('callback1'))
         emcy.add_callback(lambda err: call_order.append('callback2'))
@@ -132,7 +142,7 @@ class TestEmcy(unittest.TestCase):
 
     def test_emcy_consumer_callback_exception_handling(self):
         """Test that callback exceptions don't break other callbacks or the system."""
-        emcy = canopen.emcy.EmcyConsumer()
+        emcy = self.emcy
         successful_callbacks = []
         emcy.add_callback(lambda err: successful_callbacks.append('success1'))
         emcy.add_callback(
@@ -144,7 +154,7 @@ class TestEmcy(unittest.TestCase):
 
     def test_emcy_consumer_error_reset_variants(self):
         """Test different error reset code patterns."""
-        emcy = canopen.emcy.EmcyConsumer()
+        emcy = self.emcy
         emcy.on_emcy(0x81, b'\x01\x20\x02\x00\x01\x02\x03\x04', 1000)
         emcy.on_emcy(0x81, b'\x10\x90\x01\x04\x03\x02\x01\x00', 2000)
         self.assertEqual(len(emcy.active), 2)
@@ -157,7 +167,7 @@ class TestEmcy(unittest.TestCase):
 
     def test_emcy_consumer_wait_timeout_edge_cases(self):
         """Test wait method with various timeout scenarios."""
-        emcy = canopen.emcy.EmcyConsumer()
+        emcy = self.emcy
         result = emcy.wait(timeout=0)
         self.assertIsNone(result)
         result = emcy.wait(timeout=0.001)
@@ -165,7 +175,7 @@ class TestEmcy(unittest.TestCase):
 
     def test_emcy_consumer_wait_concurrent_errors(self):
         """Test wait method when multiple errors arrive concurrently."""
-        emcy = canopen.emcy.EmcyConsumer()
+        emcy = self.emcy
 
         def push_multiple_errors():
             emcy.on_emcy(0x81, b'\x01\x20\x01\x01\x02\x03\x04\x05', 100)
@@ -313,6 +323,7 @@ class TestEmcyIntegration(unittest.TestCase):
         self.producer = canopen.emcy.EmcyProducer(0x081)
         self.producer.network = self.net
         self.consumer = canopen.emcy.EmcyConsumer()
+        self.consumer.network = self.rx_net
         self.rx_net.subscribe(0x081, self.consumer.on_emcy)
 
     def tearDown(self):

--- a/test/test_network.py
+++ b/test/test_network.py
@@ -14,6 +14,7 @@ class TestNetwork(unittest.TestCase):
     def setUp(self):
         self.network = canopen.Network()
         self.network.NOTIFIER_SHUTDOWN_TIMEOUT = 0.0
+        self.addCleanup(self.network.disconnect)
 
     def test_network_add_node(self):
         # Add using str.

--- a/test/test_network.py
+++ b/test/test_network.py
@@ -1,12 +1,15 @@
+import asyncio
 import logging
+import threading
 import time
 import unittest
 
 import can
 
 import canopen
+from canopen.network import ExceptionGroup
 
-from .util import SAMPLE_EDS
+from .util import SAMPLE_EDS, SupressNotAwaited
 
 
 class TestNetwork(unittest.TestCase):
@@ -14,6 +17,7 @@ class TestNetwork(unittest.TestCase):
     def setUp(self):
         self.network = canopen.Network()
         self.network.NOTIFIER_SHUTDOWN_TIMEOUT = 0.0
+        self.network.FILTER_ERRORS = False
         self.addCleanup(self.network.disconnect)
 
     def test_network_add_node(self):
@@ -72,7 +76,6 @@ class TestNetwork(unittest.TestCase):
             # .disconnect() implicitly calls .check() during test tear down.
             if self.network.notifier is not None:
                 self.network.notifier.exception = None
-            self.network.disconnect()
 
         self.addCleanup(cleanup)
         self.assertIsNone(self.network.check())
@@ -81,6 +84,35 @@ class TestNetwork(unittest.TestCase):
             pass
 
         self.network.notifier.exception = Custom("fake")
+        with self.assertRaisesRegex(Custom, "fake"):
+            with self.assertLogs(level=logging.ERROR):
+                self.network.check()
+        with self.assertRaisesRegex(Custom, "fake"):
+            with self.assertLogs(level=logging.ERROR):
+                self.network.disconnect()
+
+    def test_network_check_thread(self):
+        """This test runs an actual notifier thread and verifies that the exception is detected."""
+        class Custom(Exception):
+            pass
+
+        event = threading.Event()
+
+        class FaultyListener(can.Listener):
+            def on_message_received(self, msg):
+                raise Custom("fake")
+            def on_error(self, exc):
+                # This suppress the exception from ending up as a
+                # "PytestUnraisableExceptionWarning" in the test output.
+                event.set()
+
+        self.network.connect(interface="virtual", receive_own_messages=True)
+        self.network.notifier.add_listener(FaultyListener())
+
+        self.network.send_message(0x123, [1, 2, 3, 4, 5, 6, 7, 8])
+        # Wait for the error to be processed in the listener thread
+        self.assertTrue(event.wait(timeout=0.1))
+
         with self.assertRaisesRegex(Custom, "fake"):
             with self.assertLogs(level=logging.ERROR):
                 self.network.check()
@@ -98,12 +130,72 @@ class TestNetwork(unittest.TestCase):
         self.assertEqual(node.nmt.state, 'OPERATIONAL')
         self.assertListEqual(self.network.scanner.nodes, [2])
 
+    def test_network_notify_create_task_from_thread(self):
+        self.network.connect(interface="virtual", receive_own_messages=True)
+        self.network.FILTER_ERRORS = True
+
+        async def async_callback(*args):
+            pass
+
+        event = threading.Event()
+        def callback(*args):
+            # This will fail with RuntimeError: Network is not running in async mode
+            self.network.create_task(SupressNotAwaited(async_callback(*args)))
+        def terminate(*args):
+            # This is run after the callback is done processing the exception
+            # above, and will signal the test to continue.
+            event.set()
+
+        self.network.subscribe(0x20, callback)
+        self.network.subscribe(0x20, terminate)
+
+        with self.assertLogs(level=logging.ERROR):
+            # Sending this message, will reflect back the message from the
+            # rx thread of the rxbus and then call the notify method,
+            # which will call the callback above that will fail.
+            self.network.send_message(0x20, [1, 2, 3])
+
+            # Wait for the error to be processed in the listener thread.
+            self.assertTrue(event.wait(timeout=0.1))
+
+        # The exception is raised due to self.network.FILTER_ERRORS = False
+        # The error is logged due to self.network.on_error() logging
+        with self.assertRaisesRegex(RuntimeError, "Network is not running in async mode"):
+            self.network.check()
+
+    def test_network_notify_error_handling(self):
+        self.network.connect(interface="virtual", receive_own_messages=True)
+        self.network.FILTER_ERRORS = True
+
+        event = threading.Event()
+        def callback1(*args):
+            raise RuntimeError("Callback error 1")
+        def callback2(*args):
+            raise RuntimeError("Callback error 2")
+        def terminate(*args):
+            event.set()  # Signal end of processing the exceptions
+
+        self.network.subscribe(0x20, callback1)
+        self.network.subscribe(0x20, callback2)
+        self.network.subscribe(0x20, terminate)
+
+        with self.assertLogs(level=logging.ERROR):
+            self.network.send_message(0x20, [1, 2, 3])
+
+            # Wait for the error to be processed in the listener thread.
+            self.assertTrue(event.wait(timeout=0.1))
+
+        # The exception is raised due to self.network.FILTER_ERRORS = False
+        # The error is logged due to self.network.on_error() logging
+        with self.assertRaises(ExceptionGroup) as cm:
+            self.network.check()
+        self.assertEqual(len(cm.exception.exceptions), 2)
+
     def test_network_send_message(self):
         bus = can.interface.Bus(interface="virtual")
         self.addCleanup(bus.shutdown)
 
         self.network.connect(interface="virtual")
-        self.addCleanup(self.network.disconnect)
 
         # Send standard ID
         self.network.send_message(0x123, [1, 2, 3, 4, 5, 6, 7, 8])
@@ -125,7 +217,6 @@ class TestNetwork(unittest.TestCase):
         accumulators = [] * N_HOOKS
 
         self.network.connect(interface="virtual", receive_own_messages=True)
-        self.addCleanup(self.network.disconnect)
 
         for i in range(N_HOOKS):
             accumulators.append([])
@@ -153,7 +244,6 @@ class TestNetwork(unittest.TestCase):
     def test_network_subscribe_multiple(self):
         N_HOOKS = 3
         self.network.connect(interface="virtual", receive_own_messages=True)
-        self.addCleanup(self.network.disconnect)
 
         accumulators = []
         hooks = []
@@ -203,9 +293,24 @@ class TestNetwork(unittest.TestCase):
         self.assertEqual(accumulators[1], BATCH1)
         self.assertEqual(accumulators[2], BATCH1 + [BATCH2] + [BATCH3])
 
-    def test_network_context_manager(self):
+    def test_network_subscribe_coroutine_when_no_async(self):
+        self.network.connect(interface="virtual", receive_own_messages=True)
+
+        async def async_callback(*args):
+            # WIll never be run because async isn't enabled.
+            pass
+        self.network.subscribe(0x20, SupressNotAwaited(async_callback))
+
+        # Will fail because async isn't enabled.
+        with self.assertRaises(RuntimeError):
+            with self.assertLogs(level=logging.ERROR):
+                self.network.notify(0x20, bytes([1, 2, 3]), 1000)
+
+    def test_network_context_manager(self):  #***
         with self.network.connect(interface="virtual"):
             pass
+        # This should raise an exception, since the network is disconnected
+        # when the context manager exits.
         with self.assertRaisesRegex(RuntimeError, "Not connected"):
             self.network.send_message(0, [])
 
@@ -238,7 +343,6 @@ class TestNetwork(unittest.TestCase):
         PERIOD = 0.01
         TIMEOUT = PERIOD * 10
         self.network.connect(interface="virtual")
-        self.addCleanup(self.network.disconnect)
 
         bus = can.Bus(interface="virtual")
         self.addCleanup(bus.shutdown)
@@ -289,7 +393,6 @@ class TestNetwork(unittest.TestCase):
 
     def test_network_connect_does_not_recreate_notifier(self):
         self.network.connect(interface="virtual")
-        self.addCleanup(self.network.disconnect)
         notifier1 = self.network.notifier
         self.assertIsNotNone(notifier1)
         # Calling connect() again should reuse the existing notifier
@@ -315,6 +418,95 @@ class TestNetwork(unittest.TestCase):
         # Notifier must be released even when check() raises
         self.assertIsNone(self.network.notifier)
 
+
+class TestNetworkAsync(unittest.IsolatedAsyncioTestCase):
+
+    def setUp(self):
+        self.network = canopen.Network()
+        self.network.NOTIFIER_SHUTDOWN_TIMEOUT = 0.0
+        self.network.FILTER_ERRORS = False
+        self.addCleanup(self.network.disconnect)
+
+    async def test_network_async_context_manager(self):
+        async with self.network.connect(interface="virtual"):
+            pass
+        # This should raise an exception, since the network is disconnected
+        # when the context manager exits.
+        with self.assertRaisesRegex(RuntimeError, "Not connected"):
+            self.network.send_message(0, [])
+
+    async def test_network_subscribe_coroutine(self):
+        async with self.network.connect(interface="virtual", receive_own_messages=True):
+
+            event = asyncio.Event()
+            async def async_callback(*args):
+                await asyncio.sleep(0.01)
+                event.set()
+
+            self.network.subscribe(0x20, async_callback)
+            self.network.notify(0x20, bytes([1, 2, 3]), 1000)
+
+            # The success is that this does not raise an TimeoutError
+            await asyncio.wait_for(event.wait(), timeout=0.1)  # Wait for the callback to complete.
+
+    async def test_network_notify(self):
+        with self.assertLogs():
+            self.network.add_node(2, SAMPLE_EDS)
+        node = self.network[2]
+        async def notify(*args):
+            """Simulate a notification from the network thread."""
+            await asyncio.to_thread(self.network.notify, *args)
+        await notify(0x82, b'\x01\x20\x02\x00\x01\x02\x03\x04', 1473418396.0)
+        self.assertEqual(len(node.emcy.active), 1)
+        await notify(0x702, b'\x05', 1473418396.0)
+        self.assertEqual(node.nmt.state, 'OPERATIONAL')
+        self.assertListEqual(self.network.scanner.nodes, [2])
+
+    async def test_network_notify_create_task_from_thread(self):
+        async with self.network.connect(interface="virtual", receive_own_messages=True):
+
+            event = asyncio.Event()
+            async def async_callback(*args):
+                event.set()
+
+            def callback(*args):
+                # This will fail with AttributeError: 'NoneType' object has no attribute 'call_soon_threadsafe'
+                # Because there is no running event loop.
+                self.network.create_task(async_callback(*args))
+
+            self.network.subscribe(0x20, callback)
+            self.network.send_message(0x20, [1, 2, 3])
+
+            # The success is that this does not raise an TimeoutError
+            await asyncio.wait_for(event.wait(), timeout=0.1)  # Wait for the callback to complete.
+
+    async def test_network_notify_error_handling(self):
+        async with self.network.connect(interface="virtual", receive_own_messages=True):
+            self.network.FILTER_ERRORS = True
+
+            event = asyncio.Event()
+            async def callback1(*args):
+                raise RuntimeError("Callback error 1")
+            async def callback2(*args):
+                raise RuntimeError("Callback error 2")
+            async def terminate(*args):
+                await asyncio.sleep(0.05)
+                event.set()  # Signal end of processing the exceptions
+
+            self.network.subscribe(0x20, callback1)
+            self.network.subscribe(0x20, callback2)
+            self.network.subscribe(0x20, terminate)
+
+            with self.assertLogs(level=logging.ERROR):
+                self.network.send_message(0x20, [1, 2, 3])
+                await asyncio.wait_for(event.wait(), timeout=0.1)  # Wait for the error to be processed in the listener thread.
+
+            # The success is that this does not raise an TimeoutError
+            # await asyncio.sleep(0.1)  # Wait for the callbacks to complete.
+
+            with self.assertRaises(ExceptionGroup) as cm:
+                self.network.check()
+            self.assertEqual(len(cm.exception.exceptions), 2)
 
 class TestScanner(unittest.TestCase):
     TIMEOUT = 0.1

--- a/test/test_node.py
+++ b/test/test_node.py
@@ -29,17 +29,15 @@ class TestBaseNode(unittest.TestCase):
 
 class TestLocalNode(unittest.TestCase):
 
-    @classmethod
-    def setUpClass(cls):
-        cls.network = canopen.Network()
-        cls.network.NOTIFIER_SHUTDOWN_TIMEOUT = 0.0
-        cls.network.connect(interface="virtual")
+    def setUp(self):
+        self.network = canopen.Network()
+        self.network.NOTIFIER_SHUTDOWN_TIMEOUT = 0.0
+        self.network.connect(interface="virtual")
 
-        cls.node = canopen.LocalNode(2, canopen.objectdictionary.ObjectDictionary())
+        self.node = canopen.LocalNode(2, canopen.objectdictionary.ObjectDictionary())
 
-    @classmethod
-    def tearDownClass(cls):
-        cls.network.disconnect()
+    def tearDown(self):
+        self.network.disconnect()
 
     def test_associate_network(self):
         # Need to store the number of subscribers before associating because the
@@ -78,17 +76,15 @@ class TestLocalNode(unittest.TestCase):
 
 class TestRemoteNode(unittest.TestCase):
 
-    @classmethod
-    def setUpClass(cls):
-        cls.network = canopen.Network()
-        cls.network.NOTIFIER_SHUTDOWN_TIMEOUT = 0.0
-        cls.network.connect(interface="virtual")
+    def setUp(self):
+        self.network = canopen.Network()
+        self.network.NOTIFIER_SHUTDOWN_TIMEOUT = 0.0
+        self.network.connect(interface="virtual")
 
-        cls.node = canopen.RemoteNode(2, canopen.objectdictionary.ObjectDictionary())
+        self.node = canopen.RemoteNode(2, canopen.objectdictionary.ObjectDictionary())
 
-    @classmethod
-    def tearDownClass(cls):
-        cls.network.disconnect()
+    def tearDown(self):
+        self.network.disconnect()
 
     def test_associate_network(self):
         # Need to store the number of subscribers before associating because the
@@ -102,6 +98,7 @@ class TestRemoteNode(unittest.TestCase):
         self.assertIs(self.node.tpdo.network, self.network)
         self.assertIs(self.node.rpdo.network, self.network)
         self.assertIs(self.node.nmt.network, self.network)
+        self.assertIs(self.node.emcy.network, self.network)
 
         # Test that its not possible to associate the network multiple times
         with self.assertRaises(RuntimeError) as cm:
@@ -117,6 +114,7 @@ class TestRemoteNode(unittest.TestCase):
         self.assertIs(self.node.tpdo.network, uninitalized)
         self.assertIs(self.node.rpdo.network, uninitalized)
         self.assertIs(self.node.nmt.network, uninitalized)
+        self.assertIs(self.node.emcy.network, uninitalized)
         self.assertEqual(count_subscribers(self.network), n_subscribers)
 
         # Test that its possible to deassociate the network multiple times

--- a/test/test_time.py
+++ b/test/test_time.py
@@ -19,6 +19,7 @@ class TestTime(unittest.TestCase):
 
     def test_time_producer(self):
         network = canopen.Network()
+        self.addCleanup(network.disconnect)
         network.NOTIFIER_SHUTDOWN_TIMEOUT = 0.0
         network.connect(interface="virtual", receive_own_messages=True)
         producer = canopen.timestamp.TimeProducer(network)
@@ -41,8 +42,6 @@ class TestTime(unittest.TestCase):
             ms, days = struct.unpack("<LH", msg.data)
             self.assertEqual(days, int(current_from_epoch) // 86400)
             self.assertEqual(ms, int(current_from_epoch % 86400 * 1000))
-
-        network.disconnect()
 
 
 if __name__ == "__main__":

--- a/test/util.py
+++ b/test/util.py
@@ -1,6 +1,9 @@
+import asyncio
 import contextlib
 import os
 import tempfile
+from collections.abc import Callable, Coroutine
+from typing import Optional
 
 
 DATATYPES_EDS = os.path.join(os.path.dirname(__file__), "datatypes.eds")
@@ -12,3 +15,29 @@ def tmp_file(*args, **kwds):
     with tempfile.NamedTemporaryFile(*args, **kwds) as tmp:
         tmp.close()
         yield tmp
+
+
+class SupressNotAwaited:
+    """This is a small helper to wrap a callable object in a callable object,
+    so that we can retrieve the coroutine object to suppress warnings about
+    unawaited coroutines.
+    """
+    def __init__(self, fn: Callable):
+        if not asyncio.iscoroutine(fn):
+            self._coro: Optional[Coroutine] = None
+            self._fn = fn
+        else:
+            self._coro = fn
+
+    def __call__(self, *args, **kwargs):
+        if self._coro is None:
+            self._coro = self._fn(*args, **kwargs)
+        return self._coro
+
+    def __del__(self):
+        """Suppress warnings about unawaited coroutines by closing the
+           coroutine object.
+        """
+        if self._coro is not None:
+            self._coro.close()
+            self._coro = None


### PR DESCRIPTION
This PR is the first PR (of many) that introduce asyncio support in canopen, see #272. The PRs are split into smaller, more manageable and reviewable chunks. See PR #359 for the entire asyncio feature, which this PR is an extract from.

The PR adds the basic framework for asyncio support in `Network`. It improves the CAN notification / callback system where it does error handling in a consistent way. After this PR, user provided callbacks may now be async coroutines.

This PR does not add any CAN functional asyncio support yet.

### Features

* Implement async support in `Network`.
* Using async context manager to start in async mode
* Improve error handling in notify / CAN callbacks
* Add `Network.FILTER_ERROR` to set if error in callbacks should be logged or raised
* Add `Network.create_task()` to run a coroutine under management. Multi-threaded.
* Add `Network.dispatch_callbacks()` that runs many callbacks, handling exceptions and coroutines.
* Use `network.dispatch_callbacks()` to run user provided callbacks, which can be coroutines
* Fixups on unit tests